### PR TITLE
CodeRabbit 자동 PR 리뷰 설정 추가

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,74 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+
+language: "ko-KR"
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: true
+  high_level_summary: true
+  poem: false
+  review_status: true
+
+  auto_review:
+    enabled: true
+    drafts: true
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 10
+    base_branches:
+      - "develop"
+      - "main"
+    ignore_title_keywords:
+      - "[skip review]"
+      - "[리뷰 제외]"
+    ignore_usernames:
+      - "dependabot[bot]"
+      - "github-actions[bot]"
+
+  path_filters:
+    - "!**/node_modules/**"
+    - "!**/build/**"
+    - "!**/dist/**"
+    - "!android/.gradle/**"
+    - "!android/app/build/**"
+    - "!ios/Pods/**"
+    - "!ios/build/**"
+    - "!server/uploads/**"
+    - "!**/package-lock.json"
+    - "!Gemfile.lock"
+
+  path_instructions:
+    - path: "src/**/*.{ts,tsx}"
+      instructions: |
+        React Native 앱 코드로 검토합니다.
+        - iOS와 Android에서 동작 및 레이아웃이 동일한지 확인합니다.
+        - 터치 영역, Safe Area, 키보드, 접근성과 긴 텍스트 오버플로를 확인합니다.
+        - useEffect 정리, 비동기 경쟁 상태, 불필요한 렌더링과 긴 목록 성능을 확인합니다.
+        - 기존 디자인 토큰과 아이콘 에셋을 우선 사용했는지 확인합니다.
+
+    - path: "server/**/*.js"
+      instructions: |
+        Express 및 MySQL 서버 코드로 검토합니다.
+        - 인증과 권한 검사를 우회할 수 없는지 확인합니다.
+        - SQL 인젝션, 파일 업로드, 개인정보 노출, 비밀값 하드코딩을 중점 확인합니다.
+        - 입력값 검증, 트랜잭션, 중복 요청, 동시성 및 오류 응답의 일관성을 확인합니다.
+        - DB 스키마 변경이 기존 데이터와 하위 호환되는지 확인합니다.
+
+    - path: "web/src/**/*.{ts,tsx}"
+      instructions: |
+        React 웹 코드로 검토합니다.
+        - 모바일 앱과 API 계약, 인증 정책 및 상태 표시가 일치하는지 확인합니다.
+        - 모바일부터 데스크톱까지 반응형 레이아웃과 키보드 접근성을 확인합니다.
+        - 로딩, 빈 상태, 오류 및 재시도 흐름이 누락되지 않았는지 확인합니다.
+
+    - path: "**/*.{test,spec}.{js,jsx,ts,tsx}"
+      instructions: |
+        변경된 핵심 동작의 정상·실패·경계 조건을 검증하는지 확인합니다.
+        테스트가 구현 세부사항보다 사용자 관찰 동작과 API 계약을 검증하도록 제안합니다.
+
+    - path: "android/**"
+      instructions: |
+        Android 네이티브 설정 변경이 빌드, 권한, 네트워크 보안 및 릴리스 설정에 미치는 영향을 확인합니다.
+
+    - path: "ios/**"
+      instructions: |
+        iOS 네이티브 설정 변경이 빌드, 권한, ATS, 서명 및 App Store 배포에 미치는 영향을 확인합니다.

--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ VITE_API_BASE_URL=https://api.example.com npm run web:build
 
 운영 API는 로그인 토큰과 DB의 `users.is_admin` 권한을 모두 확인합니다. 운영 환경에서는 `ADMIN_EMAILS`와 `AUTH_TOKEN_SECRET`을 비밀 환경변수로 관리합니다.
 
+## CodeRabbit 코드 리뷰
+
+저장소 루트의 `.coderabbit.yaml`은 `main`, `develop` 대상 PR과 Draft PR을 자동으로 검토하도록 설정합니다. 새 커밋을 푸시하면 변경된 부분을 증분 리뷰하며, 서버 보안·DB 호환성, React Native의 iOS/Android 일관성, 웹 API 계약을 경로별 기준으로 확인합니다.
+
+CodeRabbit GitHub App을 `C4t4ddict/kkiri-kkiri` 저장소에 설치해야 자동 리뷰가 시작됩니다. 자동 리뷰가 누락된 경우 PR 댓글에 `@coderabbitai review`를 입력하고, 전체 변경을 다시 검토하려면 `@coderabbitai full review`를 사용합니다. 리뷰를 생략해야 하는 예외 PR은 제목에 `[리뷰 제외]` 또는 `[skip review]`를 포함합니다.
+
 > **Note**: Make sure you have completed the [Set Up Your Environment](https://reactnative.dev/docs/set-up-your-environment) guide before proceeding.
 
 ## Step 1: Start Metro


### PR DESCRIPTION
## 변경 사항
- 저장소 루트에 CodeRabbit 공식 schema v2 기반 설정을 추가했습니다.
- `develop`, `main` 대상 PR과 Draft PR 자동 리뷰를 활성화했습니다.
- 새 커밋의 증분 리뷰와 중요 이슈의 변경 요청 워크플로를 활성화했습니다.
- React Native, Express/MySQL, React 웹, 테스트, iOS/Android 경로별 리뷰 기준을 추가했습니다.
- 빌드 결과물, 의존성, 업로드 파일 및 잠금 파일은 리뷰에서 제외했습니다.
- README에 설치 조건과 수동 리뷰 명령을 기록했습니다.

## 검증
- YAML 구문 검사 통과
- CodeRabbit 공식 `schema.v2.json` 검증 통과
- `git diff --check` 통과
- CodeRabbit GitHub App의 저장소 연결 확인
- 이 Draft PR에서 `.coderabbit.yaml` 기반 자동 리뷰 시작 확인

Closes #49