### PR TITLE
feat(onboarding): 신규 사용자 탭 튜토리얼 추가

### DIFF
--- a/__tests__/tutorial.test.ts
+++ b/__tests__/tutorial.test.ts
@@ -1,0 +1,29 @@
+import {
+  getTutorialPendingStorageKey,
+  getTutorialStorageKey,
+  shouldShowTutorial,
+  TUTORIAL_STEPS,
+} from '../src/onboarding/tutorial';
+
+describe('신규 사용자 튜토리얼', () => {
+  it('홈, 정보, 활동, 매칭 순서로 구성된다', () => {
+    expect(TUTORIAL_STEPS.map(step => step.tab)).toEqual([
+      '홈',
+      '정보',
+      '활동',
+      '매칭',
+    ]);
+  });
+
+  it('사용자별로 완료 상태 키를 분리한다', () => {
+    expect(getTutorialStorageKey(1)).not.toBe(getTutorialStorageKey(2));
+    expect(getTutorialStorageKey(1)).toContain('/user/1');
+    expect(getTutorialPendingStorageKey(1)).toContain('/pending/1');
+  });
+
+  it('신규 가입 대기 상태이고 미완료일 때만 노출한다', () => {
+    expect(shouldShowTutorial(null, 'pending')).toBe(true);
+    expect(shouldShowTutorial('completed', 'pending')).toBe(false);
+    expect(shouldShowTutorial(null, null)).toBe(false);
+  });
+});

--- a/server/server.js
+++ b/server/server.js
@@ -1110,7 +1110,7 @@ const registerUser = async (req, res) => {
       return res.status(400).json({ success: false, message: '등록되지 않은 학교 이메일 도메인입니다' });
     }
 
-    await portfolioDb.query(
+    const [registrationResult] = await portfolioDb.query(
       `INSERT INTO users
         (email, email_verified, account_type, school_domain, school_name, password, name, department, student_number, birth)
        VALUES (?, 1, ?, ?, ?, ?, ?, ?, ?, ?)`,
@@ -1127,7 +1127,11 @@ const registerUser = async (req, res) => {
       ],
     );
     await consumeSignupVerification(portfolioDb, verificationId);
-    return res.status(201).json({ success: true, message: '회원가입 성공' });
+    return res.status(201).json({
+      success: true,
+      message: '회원가입 성공',
+      user_id: registrationResult.insertId,
+    });
   } catch (error) {
     if (error.code === 'ER_DUP_ENTRY') {
       return res.status(409).json({ success: false, message: '이미 존재하는 이메일입니다' });

--- a/src/navigation/BottomTabNavigator.tsx
+++ b/src/navigation/BottomTabNavigator.tsx
@@ -1,64 +1,259 @@
-// src/navigation/BottomTabNavigator.tsx
-import React from 'react';
-import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
+import React, { useEffect, useState } from 'react';
+import {
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  createBottomTabNavigator,
+  type BottomTabBarProps,
+} from '@react-navigation/bottom-tabs';
+import Ionicons from 'react-native-vector-icons/Ionicons';
 import HomeScreen from '../screens/HomeScreen';
 import InfoScreen from '../screens/Info/InfoScreen';
 import ActivityScreen from '../screens/ActivityScreen';
 import MatchingScreen from '../screens/MatchingScreen';
 import MyPageScreen from '../screens/MyPageScreen';
-import { Text, Platform } from 'react-native';
-import Ionicons from 'react-native-vector-icons/Ionicons';
+import { useAuth } from '../context/AuthContext';
 import colors from '../config/colors';
+import {
+  getTutorialPendingStorageKey,
+  getTutorialStorageKey,
+  shouldShowTutorial,
+  TUTORIAL_STEPS,
+} from '../onboarding/tutorial';
 
 const Tab = createBottomTabNavigator();
+
+const TAB_META: Record<string, { icon: string }> = {
+  홈: { icon: 'home-outline' },
+  정보: { icon: 'book-outline' },
+  활동: { icon: 'pencil-outline' },
+  매칭: { icon: 'school-outline' },
+  마이페이지: { icon: 'person-outline' },
+};
+
+function TutorialTabBar({ state, descriptors, navigation }: BottomTabBarProps) {
+  const { user } = useAuth();
+  const [tutorialVisible, setTutorialVisible] = useState(false);
+  const [stepIndex, setStepIndex] = useState(0);
+  const currentStep = TUTORIAL_STEPS[stepIndex];
+
+  useEffect(() => {
+    let active = true;
+    setTutorialVisible(false);
+    setStepIndex(0);
+    if (!user?.id)
+      return () => {
+        active = false;
+      };
+
+    Promise.all([
+      AsyncStorage.getItem(getTutorialStorageKey(user.id)),
+      AsyncStorage.getItem(getTutorialPendingStorageKey(user.id)),
+    ])
+      .then(([completed, pending]) => {
+        if (!active || !shouldShowTutorial(completed, pending)) return;
+        navigation.navigate(TUTORIAL_STEPS[0].tab);
+        setTutorialVisible(true);
+      })
+      .catch(() => undefined);
+
+    return () => {
+      active = false;
+    };
+  }, [navigation, user?.id]);
+
+  const moveToStep = (nextIndex: number) => {
+    const nextStep = TUTORIAL_STEPS[nextIndex];
+    if (!nextStep) return;
+    navigation.navigate(nextStep.tab);
+    setStepIndex(nextIndex);
+  };
+
+  const finishTutorial = async () => {
+    setTutorialVisible(false);
+    if (user?.id) {
+      await Promise.all([
+        AsyncStorage.setItem(getTutorialStorageKey(user.id), 'completed'),
+        AsyncStorage.removeItem(getTutorialPendingStorageKey(user.id)),
+      ]).catch(() => undefined);
+    }
+  };
+
+  const isLastStep = stepIndex === TUTORIAL_STEPS.length - 1;
+
+  return (
+    <>
+      <View style={styles.tabBar}>
+        {state.routes.map((route, index) => {
+          const options = descriptors[route.key].options;
+          const isFocused = state.index === index;
+          const meta = TAB_META[route.name] || TAB_META.홈;
+          const color = isFocused ? colors.primary : colors.textMain;
+          const onPress = () => {
+            const event = navigation.emit({
+              type: 'tabPress',
+              target: route.key,
+              canPreventDefault: true,
+            });
+            if (!isFocused && !event.defaultPrevented)
+              navigation.navigate(route.name);
+          };
+          const onLongPress = () => {
+            navigation.emit({ type: 'tabLongPress', target: route.key });
+          };
+
+          return (
+            <Pressable
+              key={route.key}
+              accessibilityRole="button"
+              accessibilityLabel={
+                options.tabBarAccessibilityLabel || `${route.name} 탭`
+              }
+              accessibilityState={isFocused ? { selected: true } : {}}
+              onPress={onPress}
+              onLongPress={onLongPress}
+              style={styles.tabButton}
+            >
+              <Ionicons name={meta.icon} size={25} color={color} />
+              <Text style={[styles.tabLabel, { color }]}>{route.name}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      <Modal
+        visible={tutorialVisible}
+        transparent
+        statusBarTranslucent
+        animationType="fade"
+        onRequestClose={finishTutorial}
+      >
+        <View style={styles.tutorialBackdrop} accessibilityViewIsModal>
+          <View style={styles.tutorialCard}>
+            <ScrollView
+              bounces={false}
+              showsVerticalScrollIndicator={false}
+              contentContainerStyle={styles.tutorialContent}
+            >
+              <View style={styles.tutorialTopRow}>
+                <View style={styles.stepBadge}>
+                  <Text style={styles.stepBadgeText}>
+                    {stepIndex + 1} / {TUTORIAL_STEPS.length}
+                  </Text>
+                </View>
+                <TouchableOpacity
+                  accessibilityRole="button"
+                  accessibilityLabel="튜토리얼 건너뛰기"
+                  onPress={finishTutorial}
+                >
+                  <Text style={styles.skipText}>건너뛰기</Text>
+                </TouchableOpacity>
+              </View>
+
+              <View style={styles.tutorialIcon}>
+                <Ionicons
+                  name={currentStep.icon}
+                  size={28}
+                  color={colors.primary}
+                />
+              </View>
+              <Text style={styles.eyebrow}>{currentStep.eyebrow}</Text>
+              <Text style={styles.tutorialTitle}>{currentStep.title}</Text>
+              <Text style={styles.tutorialDescription}>
+                {currentStep.description}
+              </Text>
+
+              <View style={styles.pointList}>
+                {currentStep.points.map(point => (
+                  <View key={point} style={styles.pointRow}>
+                    <Ionicons
+                      name="checkmark-circle"
+                      size={18}
+                      color={colors.primary}
+                    />
+                    <Text style={styles.pointText}>{point}</Text>
+                  </View>
+                ))}
+              </View>
+
+              <View style={styles.currentTabPill}>
+                <Ionicons
+                  name={currentStep.icon}
+                  size={18}
+                  color={colors.primary}
+                />
+                <Text style={styles.currentTabText}>
+                  지금 보고 있는 곳 · {currentStep.tab}
+                </Text>
+              </View>
+
+              <View style={styles.progressRow}>
+                {TUTORIAL_STEPS.map((step, index) => (
+                  <View
+                    key={step.tab}
+                    style={[
+                      styles.progressDot,
+                      index === stepIndex && styles.progressDotActive,
+                    ]}
+                  />
+                ))}
+              </View>
+
+              <View style={styles.actionRow}>
+                <TouchableOpacity
+                  accessibilityRole="button"
+                  disabled={stepIndex === 0}
+                  onPress={() => moveToStep(stepIndex - 1)}
+                  style={[
+                    styles.previousButton,
+                    stepIndex === 0 && styles.previousButtonDisabled,
+                  ]}
+                >
+                  <Text style={styles.previousText}>이전</Text>
+                </TouchableOpacity>
+                <TouchableOpacity
+                  accessibilityRole="button"
+                  onPress={() =>
+                    isLastStep ? finishTutorial() : moveToStep(stepIndex + 1)
+                  }
+                  style={styles.nextButton}
+                >
+                  <Text style={styles.nextText}>
+                    {isLastStep ? '시작하기' : '다음'}
+                  </Text>
+                  <Ionicons
+                    name={isLastStep ? 'checkmark' : 'arrow-forward'}
+                    size={18}
+                    color="#FFFFFF"
+                  />
+                </TouchableOpacity>
+              </View>
+            </ScrollView>
+          </View>
+        </View>
+      </Modal>
+    </>
+  );
+}
+
+const renderTutorialTabBar = (props: BottomTabBarProps) => (
+  <TutorialTabBar {...props} />
+);
 
 export default function BottomTabNavigator() {
   return (
     <Tab.Navigator
-    initialRouteName="홈"
-      screenOptions={({ route }) => ({
-        tabBarIcon: ({ color, size }) => {
-          let iconName = 'home-outline';
-           switch (route.name) {
-            case '홈': iconName = 'home-outline'; break;
-            case '정보': iconName = 'book-outline'; break;
-            case '활동': iconName = 'pencil-outline'; break;
-            case '매칭': iconName = 'school-outline'; break;
-            case '마이페이지': iconName = 'person-outline'; break;
-          }
-
-          return <Ionicons name={iconName} size={size} color={color} />;
-        },
-        tabBarActiveTintColor: colors.primary,
-        tabBarInactiveTintColor: colors.textMain,
-        tabBarLabelStyle: { fontSize: 12 },
-        headerShown: false,
-        tabBarStyle: {
-          left: 0, // 좌우 여백 없이 화면 전체 너비 사용
-          right: 0, // 좌우 여백 없이 화면 전체 너비 사용
-          borderTopLeftRadius: 20, // 왼쪽 위 모서리만 둥글게
-          borderTopRightRadius: 20, // 오른쪽 위 모서리만 둥글게
-          borderRadius: 0, // 기존 borderRadius 제거 (혹시 모르니)
-          height: Platform.OS === 'ios' ? 90 : 70, // iOS는 바닥바를 포함하여 높이 조절
-          backgroundColor: '#fff',
-          // 그림자 효과 조정
-          shadowColor: '#000',
-          shadowOffset: { width: 0, height: -5 }, // 그림자를 위쪽으로 살짝 이동하여 전체적인 느낌을 줍니다.
-          shadowOpacity: 0.1, // 그림자 투명도 낮춤
-          shadowRadius: 5, // 그림자 번짐 정도 높임
-          elevation: 8, // 안드로이드 그림자 강도 높임
-          paddingBottom: Platform.OS === 'ios' ? 20 : 0, // iOS 안전 영역 고려 패딩 추가
-        },
-        tabBarIconStyle: {
-          marginTop: 5, // 아이콘 위쪽에 5px 여백 추가 (원하는 값으로 조절)
-        },
-        tabBarLabel: ({ color }) => (
-          <Text style={{ color, fontSize: 12, fontWeight: '700', marginBottom: Platform.OS === 'ios' ? 0 : 5 }}>
-            {route.name}
-          </Text>
-        ),
-        tabBarHideOnKeyboard: true,
-      })}
+      initialRouteName="홈"
+      tabBar={renderTutorialTabBar}
+      screenOptions={{ headerShown: false, tabBarHideOnKeyboard: true }}
     >
       <Tab.Screen name="홈" component={HomeScreen} />
       <Tab.Screen name="정보" component={InfoScreen} />
@@ -68,3 +263,146 @@ export default function BottomTabNavigator() {
     </Tab.Navigator>
   );
 }
+
+const styles = StyleSheet.create({
+  tabBar: {
+    flexDirection: 'row',
+    height: Platform.OS === 'ios' ? 90 : 70,
+    paddingBottom: Platform.OS === 'ios' ? 20 : 4,
+    borderTopLeftRadius: 20,
+    borderTopRightRadius: 20,
+    backgroundColor: '#FFFFFF',
+    shadowColor: '#000000',
+    shadowOffset: { width: 0, height: -5 },
+    shadowOpacity: 0.1,
+    shadowRadius: 5,
+    elevation: 8,
+  },
+  tabButton: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 4,
+    paddingTop: 5,
+  },
+  tabLabel: { fontSize: 12, fontWeight: '700' },
+  tutorialBackdrop: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    paddingHorizontal: 16,
+    paddingBottom: Platform.OS === 'ios' ? 26 : 16,
+    backgroundColor: 'rgba(16, 24, 40, 0.62)',
+  },
+  tutorialCard: {
+    maxHeight: '92%',
+    borderRadius: 26,
+    backgroundColor: '#FFFFFF',
+    overflow: 'hidden',
+    shadowColor: '#000000',
+    shadowOffset: { width: 0, height: 12 },
+    shadowOpacity: 0.2,
+    shadowRadius: 24,
+    elevation: 18,
+  },
+  tutorialContent: { padding: 22 },
+  tutorialTopRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  stepBadge: {
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
+    backgroundColor: colors.primarySurface,
+  },
+  stepBadgeText: { color: colors.primary, fontSize: 11, fontWeight: '900' },
+  skipText: { color: colors.textSub, fontSize: 13, fontWeight: '700' },
+  tutorialIcon: {
+    width: 54,
+    height: 54,
+    marginTop: 20,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.primarySurface,
+  },
+  eyebrow: {
+    marginTop: 18,
+    color: colors.primary,
+    fontSize: 12,
+    fontWeight: '900',
+  },
+  tutorialTitle: {
+    marginTop: 6,
+    color: colors.textMain,
+    fontSize: 23,
+    lineHeight: 31,
+    fontWeight: '900',
+  },
+  tutorialDescription: {
+    marginTop: 9,
+    color: colors.textSub,
+    fontSize: 14,
+    lineHeight: 21,
+  },
+  pointList: { gap: 9, marginTop: 18 },
+  pointRow: { flexDirection: 'row', alignItems: 'center', gap: 9 },
+  pointText: {
+    flex: 1,
+    color: colors.textMain,
+    fontSize: 13,
+    fontWeight: '700',
+  },
+  currentTabPill: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 7,
+    alignSelf: 'flex-start',
+    marginTop: 20,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 12,
+    backgroundColor: colors.primarySurface,
+  },
+  currentTabText: {
+    color: colors.primaryDark,
+    fontSize: 12,
+    fontWeight: '800',
+  },
+  progressRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    gap: 7,
+    marginTop: 22,
+  },
+  progressDot: {
+    width: 7,
+    height: 7,
+    borderRadius: 4,
+    backgroundColor: '#D0D5DD',
+  },
+  progressDotActive: { width: 22, backgroundColor: colors.primary },
+  actionRow: { flexDirection: 'row', gap: 10, marginTop: 20 },
+  previousButton: {
+    width: 88,
+    height: 50,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#F2F4F7',
+  },
+  previousButtonDisabled: { opacity: 0 },
+  previousText: { color: colors.textSub, fontSize: 14, fontWeight: '800' },
+  nextButton: {
+    flex: 1,
+    height: 50,
+    flexDirection: 'row',
+    gap: 7,
+    borderRadius: 14,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.primary,
+  },
+  nextText: { color: '#FFFFFF', fontSize: 14, fontWeight: '900' },
+});

--- a/src/onboarding/tutorial.ts
+++ b/src/onboarding/tutorial.ts
@@ -1,0 +1,74 @@
+export const TUTORIAL_VERSION = 1;
+
+export type TutorialTabName = '홈' | '정보' | '활동' | '매칭';
+
+export type TutorialStep = {
+  tab: TutorialTabName;
+  icon: string;
+  eyebrow: string;
+  title: string;
+  description: string;
+  points: string[];
+};
+
+export const TUTORIAL_STEPS: TutorialStep[] = [
+  {
+    tab: '홈',
+    icon: 'home-outline',
+    eyebrow: '나에게 필요한 활동을 한눈에',
+    title: '홈에서 오늘의 흐름을 확인해요',
+    description:
+      '추천 활동과 모집 현황을 빠르게 살펴보고 관심 있는 활동으로 이동할 수 있어요.',
+    points: [
+      '추천 활동 둘러보기',
+      '모집 중인 팀 수 확인',
+      '주요 기능으로 빠르게 이동',
+    ],
+  },
+  {
+    tab: '정보',
+    icon: 'book-outline',
+    eyebrow: '공모전·대외활동 탐색',
+    title: '정보 탭에서 기회를 찾아요',
+    description:
+      '카테고리와 모집 상태를 기준으로 활동을 찾고 상세 정보와 신청 기간을 확인해요.',
+    points: ['카테고리별 필터링', '접수 상태와 마감일 확인', '관심 활동 저장'],
+  },
+  {
+    tab: '활동',
+    icon: 'pencil-outline',
+    eyebrow: '목표와 팀 활동 관리',
+    title: '활동 탭에서 계획을 실행해요',
+    description:
+      '참여 중인 활동을 선택하고 일일·주간·월간 목표와 진행률을 관리할 수 있어요.',
+    points: [
+      '활동과 역할 확인',
+      '목표 추가 및 상태 변경',
+      '캘린더와 진행률 확인',
+    ],
+  },
+  {
+    tab: '매칭',
+    icon: 'school-outline',
+    eyebrow: '함께할 팀과 팀원 찾기',
+    title: '매칭 탭에서 팀을 완성해요',
+    description:
+      '관심 활동의 모집글을 찾거나 직접 팀을 만들어 조건에 맞는 팀원을 모집해요.',
+    points: [
+      '활동별 모집글 검색',
+      '학교·전국 범위 확인',
+      '팀 만들기와 지원하기',
+    ],
+  },
+];
+
+export const getTutorialStorageKey = (userId: number | string) =>
+  `@kkiri/tutorial/v${TUTORIAL_VERSION}/user/${userId}`;
+
+export const getTutorialPendingStorageKey = (userId: number | string) =>
+  `@kkiri/tutorial/v${TUTORIAL_VERSION}/pending/${userId}`;
+
+export const shouldShowTutorial = (
+  completed: string | null,
+  pending: string | null,
+) => !completed && pending === 'pending';

--- a/src/screens/RegisterScreen.tsx
+++ b/src/screens/RegisterScreen.tsx
@@ -5,6 +5,8 @@ import colors from '../config/colors';
 import { useNavigation } from '@react-navigation/native';
 import { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { RootStackParamList } from '../../App.tsx'; // 실제 경로로 수정
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { getTutorialPendingStorageKey } from '../onboarding/tutorial';
 
 type RegisterScreenNavigationProp = NativeStackNavigationProp<RootStackParamList, 'Register'>;
 
@@ -112,6 +114,12 @@ export default function RegisterScreen() {
       const result = await response.json();
 
       if (response.ok) {
+        if (result.user_id) {
+          await AsyncStorage.setItem(
+            getTutorialPendingStorageKey(result.user_id),
+            'pending',
+          ).catch(() => undefined);
+        }
         Alert.alert(
         '회원가입 성공',
         '이제 로그인할 수 있습니다.',
@@ -133,7 +141,7 @@ export default function RegisterScreen() {
   };
 
   return (
-    <SafeAreaView style={{ flex: 1, backgroundColor: 'white' }}>
+    <SafeAreaView style={styles.safeArea}>
         <ScrollView contentContainerStyle={styles.container}>
         <Text style={styles.logo}>끼리끼리</Text>
 
@@ -200,6 +208,7 @@ export default function RegisterScreen() {
 }
 
 const styles = StyleSheet.create({
+  safeArea: { flex: 1, backgroundColor: 'white' },
   container: { padding: 24 },
   logo: {
     fontSize: 28,


### PR DESCRIPTION
## 변경 내용

- 회원가입 성공 시 신규 사용자 튜토리얼 대기 상태를 사용자 ID 기준으로 저장합니다.
- 첫 로그인에서 홈 → 정보 → 활동 → 매칭 순서로 실제 탭을 이동하는 안내 모달을 제공합니다.
- 이전, 다음, 건너뛰기, 시작하기와 단계 진행 표시를 지원합니다.
- 완료 상태를 사용자별로 저장해 같은 기기에서 반복 노출되지 않도록 합니다.
- 작은 화면에서 안내 카드가 잘리지 않도록 스크롤 레이아웃을 적용했습니다.

## 수정 파일

| 파일 | 변경 이유 |
| --- | --- |
| `server/server.js` | 회원가입 성공 응답에 생성된 사용자 ID 반환 |
| `src/screens/RegisterScreen.tsx` | 신규 가입자의 튜토리얼 대기 상태 저장 |
| `src/onboarding/tutorial.ts` | 튜토리얼 단계, 저장 키, 노출 조건 정의 |
| `src/navigation/BottomTabNavigator.tsx` | 탭 전환형 튜토리얼 UI와 완료 처리 |
| `__tests__/tutorial.test.ts` | 단계 순서와 신규 사용자 노출 조건 테스트 |

## 검증

- [x] `npx tsc --noEmit`
- [x] 변경 파일 ESLint
- [x] `npm test -- --runInBand --watchman=false` (2 suites, 4 tests)
- [x] `node --test server/lib/test/*.tests.js` (28 tests)
- [x] `git diff --check`

## 연결 이슈

Closes #67

## 참고 사항

- 튜토리얼 대기·완료 상태는 사용자 ID 기준 기기 로컬 저장소에 보관합니다.
- 서버 DB 스키마 변경은 없습니다.
- 본 PR은 검토용 Draft이며 자동 머지하지 않습니다.