### PR TITLE
feat(admin): 운영자 피드백 답장 기능 추가

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -17,6 +17,8 @@ LOG_LEVEL=info
 ACTIVITY_CACHE_TTL_MS=30000
 OPS_API_TOKEN=replace-with-a-random-operations-token
 ADMIN_EMAILS=admin@example.com
+ADMIN_EMAIL=
+ADMIN_PASSWORD=
 SCHOOL_EMAIL_DOMAINS=school.ac.kr,another.ac.kr
 
 # 이메일 인증/비밀번호 재설정 SMTP

--- a/server/auth/adminAuthorization.js
+++ b/server/auth/adminAuthorization.js
@@ -1,0 +1,17 @@
+const createRequireAdmin = ({ database, getRequestUserId, getSchemaReady }) => async (req, res, next) => {
+  const userId = getRequestUserId(req);
+  if (!userId) return res.status(401).json({ message: '로그인이 필요합니다' });
+
+  try {
+    await getSchemaReady();
+    const [rows] = await database.query('SELECT is_admin FROM users WHERE id = ?', [userId]);
+    if (!rows.length || !rows[0].is_admin) {
+      return res.status(403).json({ message: '운영자 권한이 필요합니다' });
+    }
+    return next();
+  } catch (error) {
+    return next(error);
+  }
+};
+
+module.exports = { createRequireAdmin };

--- a/server/feedback/service.js
+++ b/server/feedback/service.js
@@ -12,6 +12,15 @@ const ensureDeveloperFeedbackSchema = async (db) => {
     INDEX idx_developer_feedback_user (user_id, created_at),
     INDEX idx_developer_feedback_status (status, created_at)
   ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`);
+
+  await db.query(`CREATE TABLE IF NOT EXISTS developer_feedback_replies (
+    reply_id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    feedback_id BIGINT NOT NULL,
+    admin_user_id INT NOT NULL,
+    content TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    INDEX idx_feedback_replies_feedback (feedback_id, created_at)
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`);
 };
 
 const normalizeFeedback = ({ category, content, platform }) => ({
@@ -24,8 +33,65 @@ const normalizeFeedback = ({ category, content, platform }) => ({
     : null,
 });
 
+const normalizeFeedbackReply = (content) => Array.from(String(content || '').trim()).slice(0, 2000).join('');
+
+const createReplyNotificationPreview = (content) => Array.from(String(content || '')).slice(0, 255).join('');
+
+const attachReplies = (feedbacks, replies) => {
+  const repliesByFeedback = new Map();
+  replies.forEach((reply) => {
+    const list = repliesByFeedback.get(reply.feedback_id) || [];
+    list.push(reply);
+    repliesByFeedback.set(reply.feedback_id, list);
+  });
+  return feedbacks.map((feedback) => ({
+    ...feedback,
+    replies: repliesByFeedback.get(feedback.feedback_id) || [],
+  }));
+};
+
+const createFeedbackReply = async (db, { feedbackId, adminUserId, content }) => {
+  const connection = await db.getConnection();
+  try {
+    await connection.beginTransaction();
+    const [[feedback]] = await connection.query(
+      'SELECT feedback_id, user_id FROM developer_feedback WHERE feedback_id = ? FOR UPDATE',
+      [feedbackId],
+    );
+    if (!feedback) {
+      await connection.rollback();
+      return null;
+    }
+    const [result] = await connection.query(
+      `INSERT INTO developer_feedback_replies (feedback_id, admin_user_id, content)
+       VALUES (?, ?, ?)`,
+      [feedbackId, adminUserId, content],
+    );
+    await connection.query(
+      "UPDATE developer_feedback SET status = 'REPLIED' WHERE feedback_id = ?",
+      [feedbackId],
+    );
+    await connection.query(
+      `INSERT INTO user_notifications (user_id, team_id, notice_id, type, title, content)
+       VALUES (?, NULL, NULL, 'developer_reply', '개발자 답장이 도착했어요', ?)`,
+      [feedback.user_id, createReplyNotificationPreview(content)],
+    );
+    await connection.commit();
+    return { replyId: result.insertId, userId: feedback.user_id };
+  } catch (error) {
+    await connection.rollback();
+    throw error;
+  } finally {
+    connection.release();
+  }
+};
+
 module.exports = {
+  attachReplies,
+  createFeedbackReply,
+  createReplyNotificationPreview,
   FEEDBACK_CATEGORIES,
   ensureDeveloperFeedbackSchema,
   normalizeFeedback,
+  normalizeFeedbackReply,
 };

--- a/server/lib/test/adminAuthorization.tests.js
+++ b/server/lib/test/adminAuthorization.tests.js
@@ -1,0 +1,51 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { createRequireAdmin } = require('../../auth/adminAuthorization');
+
+const createResponse = () => ({
+  statusCode: 200,
+  body: null,
+  status(code) {
+    this.statusCode = code;
+    return this;
+  },
+  json(body) {
+    this.body = body;
+    return this;
+  },
+});
+
+test('로그인하지 않은 사용자의 운영자 접근을 차단한다', async () => {
+  const response = createResponse();
+  const requireAdmin = createRequireAdmin({
+    database: { query: async () => [[]] },
+    getRequestUserId: () => null,
+    getSchemaReady: async () => {},
+  });
+  await requireAdmin({}, response, () => assert.fail('next가 호출되면 안 됩니다'));
+  assert.equal(response.statusCode, 401);
+});
+
+test('일반 사용자의 운영자 접근을 차단한다', async () => {
+  const response = createResponse();
+  const requireAdmin = createRequireAdmin({
+    database: { query: async () => [[{ is_admin: 0 }]] },
+    getRequestUserId: () => 11,
+    getSchemaReady: async () => {},
+  });
+  await requireAdmin({}, response, () => assert.fail('next가 호출되면 안 됩니다'));
+  assert.equal(response.statusCode, 403);
+});
+
+test('운영자만 운영 API 처리를 계속한다', async () => {
+  const response = createResponse();
+  let nextCalled = false;
+  const requireAdmin = createRequireAdmin({
+    database: { query: async () => [[{ is_admin: 1 }]] },
+    getRequestUserId: () => 7,
+    getSchemaReady: async () => {},
+  });
+  await requireAdmin({}, response, () => { nextCalled = true; });
+  assert.equal(nextCalled, true);
+  assert.equal(response.statusCode, 200);
+});

--- a/server/lib/test/authVerification.tests.js
+++ b/server/lib/test/authVerification.tests.js
@@ -2,7 +2,12 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const { generateCode, hashSecret } = require('../../auth/verificationService');
 const { getVerificationSubject, resetMailerForTests, sendVerificationCode } = require('../../auth/mailer');
-const { normalizeFeedback } = require('../../feedback/service');
+const {
+  attachReplies,
+  createReplyNotificationPreview,
+  normalizeFeedback,
+  normalizeFeedbackReply,
+} = require('../../feedback/service');
 
 test('이메일 인증 코드는 항상 6자리 숫자로 생성된다', () => {
   for (let index = 0; index < 20; index += 1) {
@@ -61,4 +66,22 @@ test('개발자 피드백 입력을 허용된 범위로 정규화한다', () => 
     platform: 'ios',
   });
   assert.equal(normalizeFeedback({ category: 'unknown' }).category, 'OTHER');
+});
+
+test('개발자 답장을 공백과 유니코드 경계에 맞춰 정규화한다', () => {
+  assert.equal(normalizeFeedbackReply('  확인했습니다.  '), '확인했습니다.');
+  assert.equal(Array.from(normalizeFeedbackReply('😀'.repeat(2001))).length, 2000);
+  assert.equal(Array.from(createReplyNotificationPreview('😀'.repeat(300))).length, 255);
+});
+
+test('사용자 피드백에 해당 답장만 시간 순서대로 연결한다', () => {
+  const feedbacks = [{ feedback_id: 1 }, { feedback_id: 2 }];
+  const replies = [
+    { reply_id: 10, feedback_id: 1, content: '첫 답장' },
+    { reply_id: 11, feedback_id: 1, content: '추가 답장' },
+  ];
+  assert.deepEqual(attachReplies(feedbacks, replies), [
+    { feedback_id: 1, replies },
+    { feedback_id: 2, replies: [] },
+  ]);
 });

--- a/server/lib/test/feedbackReply.tests.js
+++ b/server/lib/test/feedbackReply.tests.js
@@ -1,0 +1,52 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { createFeedbackReply } = require('../../feedback/service');
+
+const createDatabase = ({ feedback = { feedback_id: 3, user_id: 17 }, failure } = {}) => {
+  const events = [];
+  const connection = {
+    async beginTransaction() { events.push('begin'); },
+    async commit() { events.push('commit'); },
+    async rollback() { events.push('rollback'); },
+    release() { events.push('release'); },
+    async query(sql, values) {
+      events.push({ sql, values });
+      if (failure && sql.includes(failure)) throw new Error('database failure');
+      if (sql.startsWith('SELECT feedback_id')) return [[feedback].filter(Boolean)];
+      if (sql.includes('INSERT INTO developer_feedback_replies')) return [{ insertId: 91 }];
+      return [{ affectedRows: 1 }];
+    },
+  };
+  return { database: { getConnection: async () => connection }, events };
+};
+
+test('운영자 답장과 사용자 공지 알림을 하나의 트랜잭션으로 저장한다', async () => {
+  const { database, events } = createDatabase();
+  const result = await createFeedbackReply(database, {
+    feedbackId: 3,
+    adminUserId: 9,
+    content: '확인 후 수정했습니다.',
+  });
+  assert.deepEqual(result, { replyId: 91, userId: 17 });
+  assert.equal(events[0], 'begin');
+  assert.equal(events.at(-2), 'commit');
+  assert.equal(events.at(-1), 'release');
+  const notification = events.find((event) => typeof event === 'object' && event.sql.includes('INSERT INTO user_notifications'));
+  assert.deepEqual(notification.values, [17, '확인 후 수정했습니다.']);
+});
+
+test('피드백이 없으면 답장과 알림을 만들지 않고 롤백한다', async () => {
+  const { database, events } = createDatabase({ feedback: null });
+  assert.equal(await createFeedbackReply(database, { feedbackId: 404, adminUserId: 9, content: '답장' }), null);
+  assert.deepEqual(events.filter((event) => typeof event === 'string'), ['begin', 'rollback', 'release']);
+});
+
+test('알림 저장이 실패하면 답장까지 함께 롤백한다', async () => {
+  const { database, events } = createDatabase({ failure: 'INSERT INTO user_notifications' });
+  await assert.rejects(
+    createFeedbackReply(database, { feedbackId: 3, adminUserId: 9, content: '답장' }),
+    /database failure/,
+  );
+  assert.equal(events.includes('commit'), false);
+  assert.deepEqual(events.slice(-2), ['rollback', 'release']);
+});

--- a/server/package.json
+++ b/server/package.json
@@ -7,6 +7,7 @@
     "crawl:competitions": "node crawler/index.js",
     "crawl:competitions:dry": "node crawler/index.js --dry-run --limit 5",
     "seed:demo-activity": "node seeds/seedCurrentActivity.js",
+    "admin:provision": "node scripts/provisionAdmin.js",
     "test": "node --test applications/test/*.tests.js crawler/test/*.tests.js portfolio/test/*.tests.js lib/test/*.tests.js"
   },
   "keywords": [],

--- a/server/scripts/provisionAdmin.js
+++ b/server/scripts/provisionAdmin.js
@@ -1,0 +1,53 @@
+const path = require('path');
+const bcrypt = require('bcryptjs');
+const mysql = require('mysql2/promise');
+
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
+
+const email = String(process.env.ADMIN_EMAIL || '').trim().toLowerCase();
+const password = String(process.env.ADMIN_PASSWORD || '');
+const allowedAdminEmails = String(process.env.ADMIN_EMAILS || '')
+  .split(',')
+  .map((value) => value.trim().toLowerCase())
+  .filter(Boolean);
+
+if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email) || password.length < 12 || !allowedAdminEmails.includes(email)) {
+  console.error('운영자 계정 환경변수 설정을 확인해주세요.');
+  process.exit(1);
+}
+
+const run = async () => {
+  const connection = await mysql.createConnection({
+    host: process.env.DB_HOST || 'localhost',
+    user: process.env.DB_USER || 'root',
+    password: process.env.DB_PASSWORD || '',
+    database: process.env.DB_NAME || 'myappdb',
+    port: Number(process.env.DB_PORT || 3306),
+    charset: 'utf8mb4',
+  });
+
+  try {
+    const [adminColumns] = await connection.query("SHOW COLUMNS FROM users LIKE 'is_admin'");
+    if (!adminColumns.length) {
+      await connection.query('ALTER TABLE users ADD COLUMN is_admin TINYINT(1) NOT NULL DEFAULT 0');
+    }
+    const passwordHash = await bcrypt.hash(password, 12);
+    const [result] = await connection.execute(
+      `UPDATE users
+       SET password = ?, email_verified = 1, is_admin = 1
+       WHERE LOWER(email) = ?`,
+      [passwordHash, email],
+    );
+    if (!result.affectedRows) {
+      throw new Error('먼저 일반 회원가입으로 생성된 계정이 필요합니다.');
+    }
+    console.log('운영자 계정 준비 완료');
+  } finally {
+    await connection.end();
+  }
+};
+
+run().catch((error) => {
+  console.error(`운영자 계정 준비 실패: ${error.message}`);
+  process.exit(1);
+});

--- a/server/server.js
+++ b/server/server.js
@@ -59,7 +59,14 @@ const {
   resetPasswordWithToken,
   verifyEmailCode,
 } = require('./auth/verificationService');
-const { ensureDeveloperFeedbackSchema, normalizeFeedback } = require('./feedback/service');
+const { createRequireAdmin } = require('./auth/adminAuthorization');
+const {
+  attachReplies,
+  createFeedbackReply,
+  ensureDeveloperFeedbackSchema,
+  normalizeFeedback,
+  normalizeFeedbackReply,
+} = require('./feedback/service');
 
 const app = express();
 const PORT = Number(process.env.PORT || 3000);
@@ -353,7 +360,7 @@ const ensureActivityTables = () => {
     `CREATE TABLE IF NOT EXISTS user_notifications (
       notification_id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
       user_id INT NOT NULL,
-      team_id INT NOT NULL,
+      team_id INT NULL,
       notice_id INT NULL,
       type VARCHAR(32) NOT NULL,
       title VARCHAR(160) NOT NULL,
@@ -520,7 +527,7 @@ const ensureMatchingInvitationSchema = async () => {
   await portfolioDb.query(`CREATE TABLE IF NOT EXISTS user_notifications (
     notification_id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
     user_id INT NOT NULL,
-    team_id INT NOT NULL,
+    team_id INT NULL,
     notice_id INT NULL,
     offer_id INT NULL,
     type VARCHAR(32) NOT NULL,
@@ -536,6 +543,10 @@ const ensureMatchingInvitationSchema = async () => {
   const existingColumns = new Set(notificationColumns.map((column) => column.Field));
   if (!existingColumns.has('offer_id')) {
     await portfolioDb.query('ALTER TABLE user_notifications ADD COLUMN offer_id INT NULL AFTER notice_id');
+  }
+  const teamIdColumn = notificationColumns.find((column) => column.Field === 'team_id');
+  if (teamIdColumn?.Null === 'NO') {
+    await portfolioDb.query('ALTER TABLE user_notifications MODIFY COLUMN team_id INT NULL');
   }
 
   const [notificationIndexes] = await portfolioDb.query(
@@ -577,20 +588,11 @@ const ensureAdminSchema = async () => {
   }
 };
 
-const requireAdmin = async (req, res, next) => {
-  const userId = getRequestUserId(req);
-  if (!userId) return res.status(401).json({ message: '로그인이 필요합니다' });
-  try {
-    await adminSchemaReady;
-    const [rows] = await portfolioDb.query('SELECT is_admin FROM users WHERE id = ?', [userId]);
-    if (!rows.length || !rows[0].is_admin) {
-      return res.status(403).json({ message: '운영자 권한이 필요합니다' });
-    }
-    next();
-  } catch (error) {
-    next(error);
-  }
-};
+const requireAdmin = createRequireAdmin({
+  database: portfolioDb,
+  getRequestUserId,
+  getSchemaReady: () => adminSchemaReady,
+});
 
 const ensureRecruitmentTeam = async (connection, recruitment) => {
   let teamId = Number(recruitment.team_id || 0);
@@ -1155,10 +1157,92 @@ app.get('/api/developer-feedback/mine', async (req, res) => {
        LIMIT 20`,
       [userId],
     );
-    res.json(rows);
+    if (!rows.length) return res.json([]);
+    const [replies] = await portfolioDb.query(
+      `SELECT reply_id, feedback_id, content, created_at
+       FROM developer_feedback_replies
+       WHERE feedback_id IN (${rows.map(() => '?').join(', ')})
+       ORDER BY created_at ASC, reply_id ASC`,
+      rows.map((row) => row.feedback_id),
+    );
+    res.json(attachReplies(rows, replies));
   } catch (error) {
     logger.error('developer_feedback_list_failed', { userId, error: error.message });
     res.status(500).json({ message: '전달 내역을 불러오지 못했습니다' });
+  }
+});
+
+app.get('/api/admin/developer-feedback', requireAdmin, async (req, res) => {
+  try {
+    await feedbackSchemaReady;
+    const [rows] = await portfolioDb.query(
+      `SELECT feedback.feedback_id, feedback.user_id, feedback.category, feedback.content,
+              feedback.platform, feedback.status, feedback.created_at,
+              users.name AS user_name, users.email AS user_email,
+              (SELECT COUNT(*) FROM developer_feedback_replies reply
+               WHERE reply.feedback_id = feedback.feedback_id) AS reply_count
+       FROM developer_feedback feedback
+       JOIN users ON users.id = feedback.user_id
+       ORDER BY feedback.created_at DESC, feedback.feedback_id DESC
+       LIMIT 100`,
+    );
+    res.json(rows || []);
+  } catch (error) {
+    logger.error('admin_feedback_list_failed', { error: error.message });
+    res.status(500).json({ message: '사용자 의견을 불러오지 못했습니다' });
+  }
+});
+
+app.get('/api/admin/developer-feedback/:feedbackId', requireAdmin, async (req, res) => {
+  const feedbackId = Number(req.params.feedbackId);
+  if (!Number.isInteger(feedbackId) || feedbackId <= 0) {
+    return res.status(400).json({ message: '올바른 의견 번호가 필요합니다' });
+  }
+  try {
+    await feedbackSchemaReady;
+    const [[feedback]] = await portfolioDb.query(
+      `SELECT feedback.feedback_id, feedback.user_id, feedback.category, feedback.content,
+              feedback.platform, feedback.status, feedback.created_at,
+              users.name AS user_name, users.email AS user_email
+       FROM developer_feedback feedback
+       JOIN users ON users.id = feedback.user_id
+       WHERE feedback.feedback_id = ?`,
+      [feedbackId],
+    );
+    if (!feedback) return res.status(404).json({ message: '전달된 의견을 찾을 수 없습니다' });
+    const [replies] = await portfolioDb.query(
+      `SELECT reply_id, content, created_at
+       FROM developer_feedback_replies
+       WHERE feedback_id = ?
+       ORDER BY created_at ASC, reply_id ASC`,
+      [feedbackId],
+    );
+    res.json({ ...feedback, replies });
+  } catch (error) {
+    logger.error('admin_feedback_detail_failed', { feedbackId, error: error.message });
+    res.status(500).json({ message: '사용자 의견을 불러오지 못했습니다' });
+  }
+});
+
+app.post('/api/admin/developer-feedback/:feedbackId/replies', requireAdmin, async (req, res) => {
+  const adminUserId = getRequestUserId(req);
+  const feedbackId = Number(req.params.feedbackId);
+  const rawContent = String(req.body?.content || '').trim();
+  const content = normalizeFeedbackReply(rawContent);
+  if (!Number.isInteger(feedbackId) || feedbackId <= 0 || !content || Array.from(rawContent).length > 2000) {
+    return res.status(400).json({ message: '답장 내용을 1자 이상 2,000자 이하로 입력해주세요' });
+  }
+
+  await Promise.all([feedbackSchemaReady, matchingSchemaReady]);
+  try {
+    const result = await createFeedbackReply(portfolioDb, { feedbackId, adminUserId, content });
+    if (!result) {
+      return res.status(404).json({ message: '전달된 의견을 찾을 수 없습니다' });
+    }
+    res.status(201).json({ success: true, reply_id: result.replyId });
+  } catch (error) {
+    logger.error('admin_feedback_reply_failed', { feedbackId, error: error.message });
+    res.status(500).json({ message: '답장을 전송하지 못했습니다' });
   }
 });
 

--- a/src/screens/AdminScreen.tsx
+++ b/src/screens/AdminScreen.tsx
@@ -41,6 +41,20 @@ type Overview = {
   crawlerRunning: boolean;
 };
 
+type DeveloperFeedback = {
+  feedback_id: number;
+  user_id: number;
+  user_name: string;
+  user_email: string;
+  category: string;
+  content: string;
+  status: string;
+  platform?: string | null;
+  reply_count: number;
+  created_at: string;
+  replies?: Array<{ reply_id: number; content: string; created_at: string }>;
+};
+
 const filters = [
   ['all', '전체'],
   ['missing_image', '이미지 누락'],
@@ -58,6 +72,12 @@ export default function AdminScreen() {
   const [refreshing, setRefreshing] = useState(false);
   const [error, setError] = useState('');
   const [editing, setEditing] = useState<Activity | null>(null);
+  const [section, setSection] = useState<'activities' | 'feedback'>('activities');
+  const [feedbacks, setFeedbacks] = useState<DeveloperFeedback[]>([]);
+  const [feedbackError, setFeedbackError] = useState('');
+  const [selectedFeedback, setSelectedFeedback] = useState<DeveloperFeedback | null>(null);
+  const [reply, setReply] = useState('');
+  const [replying, setReplying] = useState(false);
 
   const request = useCallback(async (path: string, init?: RequestInit) => {
     const response = await fetch(`${API_BASE_URL}${path}`, init);
@@ -65,6 +85,17 @@ export default function AdminScreen() {
     if (!response.ok) throw new Error(data.message || '운영 정보를 처리하지 못했습니다');
     return data;
   }, []);
+
+  const loadFeedbacks = useCallback(async () => {
+    if (!user?.is_admin) return;
+    try {
+      const feedbackData = await request('/api/admin/developer-feedback');
+      setFeedbacks(Array.isArray(feedbackData) ? feedbackData : []);
+      setFeedbackError('');
+    } catch (loadError) {
+      setFeedbackError(loadError instanceof Error ? loadError.message : '사용자 의견을 불러오지 못했습니다');
+    }
+  }, [request, user?.is_admin]);
 
   const load = useCallback(async (silent = false) => {
     if (!user?.is_admin) return;
@@ -86,13 +117,16 @@ export default function AdminScreen() {
   }, [quality, request, search, user?.is_admin]);
 
   useEffect(() => {
-    const timer = setTimeout(() => load(), 250);
+    const timer = setTimeout(() => {
+      load();
+      loadFeedbacks();
+    }, 250);
     return () => clearTimeout(timer);
-  }, [load]);
+  }, [load, loadFeedbacks]);
 
   const refresh = async () => {
     setRefreshing(true);
-    await load(true);
+    await Promise.all([load(true), loadFeedbacks()]);
     setRefreshing(false);
   };
 
@@ -112,6 +146,39 @@ export default function AdminScreen() {
       await load(true);
     } catch (runError) {
       Alert.alert('실행 실패', runError instanceof Error ? runError.message : '크롤러를 실행하지 못했습니다');
+    }
+  };
+
+  const closeReplyModal = () => {
+    setReply('');
+    setSelectedFeedback(null);
+  };
+
+  const openFeedback = async (feedbackId: number) => {
+    try {
+      const detail = await request(`/api/admin/developer-feedback/${feedbackId}`);
+      setSelectedFeedback(detail);
+    } catch (detailError) {
+      Alert.alert('조회 실패', detailError instanceof Error ? detailError.message : '사용자 의견을 불러오지 못했습니다');
+    }
+  };
+
+  const sendReply = async () => {
+    if (!selectedFeedback || !reply.trim() || replying) return;
+    setReplying(true);
+    try {
+      await request(`/api/admin/developer-feedback/${selectedFeedback.feedback_id}/replies`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ content: reply }),
+      });
+      closeReplyModal();
+      await loadFeedbacks();
+      Alert.alert('전송 완료', '사용자의 공지 알림으로 답장을 보냈습니다.');
+    } catch (replyError) {
+      Alert.alert('전송 실패', replyError instanceof Error ? replyError.message : '답장을 보내지 못했습니다');
+    } finally {
+      setReplying(false);
     }
   };
 
@@ -146,6 +213,44 @@ export default function AdminScreen() {
           </Pressable>
         </View>
 
+        <View style={styles.sectionTabs}>
+          <Pressable style={[styles.sectionTab, section === 'activities' && styles.sectionTabActive]} onPress={() => setSection('activities')}>
+            <Text style={[styles.sectionTabText, section === 'activities' && styles.sectionTabTextActive]}>활동 운영</Text>
+          </Pressable>
+          <Pressable style={[styles.sectionTab, section === 'feedback' && styles.sectionTabActive]} onPress={() => setSection('feedback')}>
+            <Text style={[styles.sectionTabText, section === 'feedback' && styles.sectionTabTextActive]}>사용자 의견</Text>
+            {feedbacks.some((item) => !Number(item.reply_count)) ? (
+              <View style={styles.feedbackCount}>
+                <Text style={styles.feedbackCountText}>{feedbacks.filter((item) => !Number(item.reply_count)).length}</Text>
+              </View>
+            ) : null}
+          </Pressable>
+        </View>
+
+        {section === 'feedback' ? (
+          <View>
+            <View style={styles.sectionHeader}>
+              <Text style={styles.sectionTitle}>개발자에게 한마디</Text>
+              <Text style={styles.sectionCount}>{feedbacks.length}건</Text>
+            </View>
+            {feedbackError ? <ScreenState kind="error" title={feedbackError} onRetry={loadFeedbacks} /> : null}
+            {!feedbackError && feedbacks.map((feedback) => (
+              <Pressable key={feedback.feedback_id} style={styles.feedbackCard} onPress={() => openFeedback(feedback.feedback_id)}>
+                <View style={styles.feedbackTop}>
+                  <Text style={styles.feedbackAuthor} numberOfLines={1}>{feedback.user_name} · {feedback.user_email}</Text>
+                  <Text style={[styles.feedbackStatus, Number(feedback.reply_count) > 0 && styles.feedbackStatusDone]}>
+                    {Number(feedback.reply_count) > 0 ? '답장 완료' : '답장 필요'}
+                  </Text>
+                </View>
+                <Text style={styles.feedbackContent} numberOfLines={3}>{feedback.content}</Text>
+                <Text style={styles.feedbackMeta}>{feedback.category} · {feedback.platform || 'unknown'} · {String(feedback.created_at).slice(0, 10)}</Text>
+              </Pressable>
+            ))}
+            {!feedbackError && !feedbacks.length ? <ScreenState kind="empty" title="전달된 사용자 의견이 없습니다" /> : null}
+          </View>
+        ) : null}
+
+        {section === 'activities' ? <View>
         <View style={styles.countGrid}>
           {countCards.map(([label, value, icon]) => (
             <View key={String(label)} style={styles.countCard}>
@@ -231,6 +336,7 @@ export default function AdminScreen() {
           </View>
         ))}
         {!overview?.crawlerErrors?.length ? <Text style={styles.noErrors}>최근 수집 오류가 없습니다.</Text> : null}
+        </View> : null}
       </ScrollView>
 
       <EditActivityModal
@@ -241,6 +347,39 @@ export default function AdminScreen() {
           setEditing(null);
         }}
       />
+      <Modal visible={Boolean(selectedFeedback)} transparent animationType="slide" onRequestClose={closeReplyModal}>
+        <View style={styles.modalBackdrop}>
+          <View style={styles.modalCard}>
+            <View style={styles.modalHeader}>
+              <Text style={styles.modalTitle}>사용자 의견 답장</Text>
+              <Pressable onPress={closeReplyModal}><Icon name="close" size={24} color="#344054" /></Pressable>
+            </View>
+            <ScrollView style={styles.replyModalScroll} keyboardShouldPersistTaps="handled">
+            <Text style={styles.replyAuthor}>{selectedFeedback?.user_name} · {selectedFeedback?.user_email}</Text>
+            <Text style={styles.replyOriginal}>{selectedFeedback?.content}</Text>
+            {(selectedFeedback?.replies || []).map((item) => (
+              <View key={item.reply_id} style={styles.previousReply}>
+                <Text style={styles.previousReplyDate}>{String(item.created_at).slice(0, 10)}</Text>
+                <Text style={styles.previousReplyText}>{item.content}</Text>
+              </View>
+            ))}
+            <TextInput
+              value={reply}
+              onChangeText={(value) => setReply(Array.from(value).slice(0, 2000).join(''))}
+              placeholder="확인 내용과 답변을 입력하세요"
+              placeholderTextColor="#98A2B3"
+              multiline
+              textAlignVertical="top"
+              style={styles.replyInput}
+            />
+            <Text style={styles.replyCount}>{Array.from(reply).length}/2000</Text>
+            <Pressable disabled={!reply.trim() || replying} onPress={sendReply} style={[styles.modalSave, (!reply.trim() || replying) && styles.replyDisabled]}>
+              <Text style={styles.modalSaveText}>{replying ? '전송 중...' : '공지 알림으로 답장'}</Text>
+            </Pressable>
+            </ScrollView>
+          </View>
+        </View>
+      </Modal>
     </View>
   );
 }
@@ -313,6 +452,13 @@ const styles = StyleSheet.create({
   heroSubtitle: { marginTop: 7, color: '#D9D1FF', fontSize: 12 },
   crawlerButton: { alignSelf: 'flex-start', flexDirection: 'row', alignItems: 'center', gap: 6, marginTop: 18, paddingHorizontal: 13, paddingVertical: 9, borderRadius: 11, backgroundColor: colors.primary },
   crawlerButtonText: { color: '#FFFFFF', fontSize: 12, fontWeight: '900' },
+  sectionTabs: { flexDirection: 'row', gap: 8, marginTop: 16, padding: 5, borderRadius: 15, backgroundColor: '#ECEEF4' },
+  sectionTab: { flex: 1, minHeight: 42, flexDirection: 'row', alignItems: 'center', justifyContent: 'center', gap: 6, borderRadius: 11 },
+  sectionTabActive: { backgroundColor: '#FFFFFF' },
+  sectionTabText: { color: '#667085', fontSize: 13, fontWeight: '800' },
+  sectionTabTextActive: { color: colors.primary },
+  feedbackCount: { minWidth: 19, height: 19, paddingHorizontal: 5, alignItems: 'center', justifyContent: 'center', borderRadius: 10, backgroundColor: colors.primary },
+  feedbackCountText: { color: '#FFFFFF', fontSize: 9, fontWeight: '900' },
   countGrid: { flexDirection: 'row', flexWrap: 'wrap', gap: 10, marginVertical: 18 },
   countCard: { width: '48.5%', padding: 16, borderWidth: 1, borderColor: '#E4E7EC', borderRadius: 18, backgroundColor: '#FFFFFF' },
   countValue: { marginTop: 12, color: '#101828', fontSize: 22, fontWeight: '900' },
@@ -348,8 +494,15 @@ const styles = StyleSheet.create({
   errorTitle: { color: '#344054', fontSize: 11, fontWeight: '900' },
   errorMessage: { marginTop: 5, color: '#667085', fontSize: 10, lineHeight: 15 },
   noErrors: { color: '#667085', fontSize: 12 },
+  feedbackCard: { marginBottom: 9, padding: 15, borderWidth: 1, borderColor: '#E4E7EC', borderRadius: 16, backgroundColor: '#FFFFFF' },
+  feedbackTop: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', gap: 10 },
+  feedbackAuthor: { flex: 1, color: '#344054', fontSize: 11, fontWeight: '800' },
+  feedbackStatus: { paddingHorizontal: 7, paddingVertical: 4, borderRadius: 8, overflow: 'hidden', color: '#B54708', backgroundColor: '#FFFAEB', fontSize: 9, fontWeight: '900' },
+  feedbackStatusDone: { color: '#067647', backgroundColor: '#ECFDF3' },
+  feedbackContent: { marginTop: 10, color: '#101828', fontSize: 13, lineHeight: 19 },
+  feedbackMeta: { marginTop: 9, color: '#98A2B3', fontSize: 10 },
   modalBackdrop: { flex: 1, justifyContent: 'flex-end', backgroundColor: 'rgba(16,24,40,0.45)' },
-  modalCard: { padding: 22, paddingBottom: 34, borderTopLeftRadius: 26, borderTopRightRadius: 26, backgroundColor: '#FFFFFF' },
+  modalCard: { maxHeight: '88%', padding: 22, paddingBottom: 34, borderTopLeftRadius: 26, borderTopRightRadius: 26, backgroundColor: '#FFFFFF' },
   modalHeader: { flexDirection: 'row', alignItems: 'center', justifyContent: 'space-between', marginBottom: 18 },
   modalTitle: { color: '#101828', fontSize: 19, fontWeight: '900' },
   modalField: { marginBottom: 13 },
@@ -357,4 +510,13 @@ const styles = StyleSheet.create({
   modalInput: { height: 46, paddingHorizontal: 13, borderWidth: 1, borderColor: '#D0D5DD', borderRadius: 12, color: '#101828' },
   modalSave: { height: 50, marginTop: 7, alignItems: 'center', justifyContent: 'center', borderRadius: 14, backgroundColor: colors.primary },
   modalSaveText: { color: '#FFFFFF', fontSize: 14, fontWeight: '900' },
+  replyAuthor: { color: colors.primary, fontSize: 11, fontWeight: '900' },
+  replyModalScroll: { flexShrink: 1 },
+  replyOriginal: { marginTop: 10, padding: 13, borderRadius: 12, color: '#344054', fontSize: 12, lineHeight: 18, backgroundColor: '#F2F4F7' },
+  previousReply: { marginTop: 8, padding: 10, borderLeftWidth: 3, borderLeftColor: colors.primaryLight, backgroundColor: colors.primarySurface },
+  previousReplyDate: { color: '#667085', fontSize: 9, fontWeight: '800' },
+  previousReplyText: { marginTop: 4, color: '#344054', fontSize: 11, lineHeight: 17 },
+  replyInput: { height: 140, marginTop: 14, padding: 14, borderWidth: 1, borderColor: '#D0D5DD', borderRadius: 13, color: '#101828', fontSize: 13, lineHeight: 19 },
+  replyCount: { marginTop: 5, textAlign: 'right', color: '#98A2B3', fontSize: 9 },
+  replyDisabled: { opacity: 0.45 },
 });

--- a/src/screens/DeveloperFeedbackScreen.tsx
+++ b/src/screens/DeveloperFeedbackScreen.tsx
@@ -26,6 +26,7 @@ type Feedback = {
   content: string;
   status: string;
   created_at: string;
+  replies?: Array<{ reply_id: number; content: string; created_at: string }>;
 };
 
 export default function DeveloperFeedbackScreen() {
@@ -123,6 +124,12 @@ export default function DeveloperFeedbackScreen() {
               {CATEGORIES.find((item) => item.value === feedback.category)?.label || '기타'} · {String(feedback.created_at).slice(0, 10)}
             </Text>
             <Text style={styles.historyContent} numberOfLines={3}>{feedback.content}</Text>
+            {(feedback.replies || []).map((reply) => (
+              <View key={reply.reply_id} style={styles.replyCard}>
+                <Text style={styles.replyLabel}>개발자 답장 · {String(reply.created_at).slice(0, 10)}</Text>
+                <Text style={styles.replyContent}>{reply.content}</Text>
+              </View>
+            ))}
           </View>
         ))}
       </ScrollView>
@@ -152,4 +159,7 @@ const styles = StyleSheet.create({
   historyCard: { marginBottom: 10, padding: 15, borderRadius: 15, backgroundColor: colors.inputBackground },
   historyMeta: { color: colors.primary, fontSize: 11, fontWeight: '800' },
   historyContent: { marginTop: 7, color: colors.textMain, fontSize: 13, lineHeight: 19 },
+  replyCard: { marginTop: 11, padding: 12, borderLeftWidth: 3, borderLeftColor: colors.primary, borderRadius: 10, backgroundColor: '#FFFFFF' },
+  replyLabel: { color: colors.primary, fontSize: 10, fontWeight: '900' },
+  replyContent: { marginTop: 6, color: colors.textMain, fontSize: 12, lineHeight: 18 },
 });

--- a/src/screens/NotificationScreen.tsx
+++ b/src/screens/NotificationScreen.tsx
@@ -6,7 +6,7 @@ import colors from '../config/colors';
 
 type Notification = {
   notification_id: number;
-  type: 'notice' | 'notice_comment' | 'team_invitation';
+  type: 'notice' | 'notice_comment' | 'team_invitation' | 'developer_reply';
   title: string;
   content: string;
   created_at: string;
@@ -56,9 +56,10 @@ export default function NotificationScreen() {
   }, [user?.id]);
 
   useFocusEffect(useCallback(() => { loadNotifications(); }, [loadNotifications]));
+  const isNotice = (item: Notification) => ['notice', 'developer_reply'].includes(item.type);
   const data = tab === '활동'
-    ? items.filter((item) => item.type !== 'notice')
-    : items.filter((item) => item.type === 'notice');
+    ? items.filter((item) => !isNotice(item))
+    : items.filter(isNotice);
 
   const respondToOffer = async (item: Notification, decision: 'ACCEPTED' | 'REJECTED') => {
     if (!user?.id || !item.offer_id || respondingOfferId) return;
@@ -89,7 +90,7 @@ export default function NotificationScreen() {
             <Text style={[styles.tabText, tab === item && styles.tabTextActive]}>{item}</Text>
           </TouchableOpacity>
         ))}
-        <View style={[styles.tabActiveBar, tab === '활동' ? { left: 0 } : { left: '50%' }]} />
+        <View style={[styles.tabActiveBar, tab === '활동' ? styles.tabActivity : styles.tabNotice]} />
       </View>
       {loading ? <ActivityIndicator style={styles.loading} color={colors.primary} /> : (
         <FlatList
@@ -99,12 +100,18 @@ export default function NotificationScreen() {
             <View style={[styles.card, !item.is_read && styles.unreadCard]}>
               <View style={styles.cardTop}>
                 <Text style={styles.channel}>
-                  {item.type === 'team_invitation' ? '팀 합류 제안' : item.type === 'notice_comment' ? '댓글 알림' : '공지 알림'}
+                  {item.type === 'team_invitation'
+                    ? '팀 합류 제안'
+                    : item.type === 'notice_comment'
+                      ? '댓글 알림'
+                      : item.type === 'developer_reply'
+                        ? '개발자 답장'
+                        : '공지 알림'}
                 </Text>
                 <Text style={styles.time}>{relativeTime(item.created_at)}</Text>
               </View>
               <Text style={styles.title}>{item.title}</Text>
-              <Text style={styles.content} numberOfLines={1}>{item.content}</Text>
+              <Text style={styles.content} numberOfLines={item.type === 'developer_reply' ? 5 : 2}>{item.content}</Text>
               {item.type === 'team_invitation' && item.offer_id ? (
                 item.offer_status === 'PENDING' ? (
                   <View style={styles.offerActions}>
@@ -152,6 +159,8 @@ const styles = StyleSheet.create({
   tabTextActive: { color: colors.textMain, fontWeight: '700' },
   tabBaseLine: { position: 'absolute', left: 0, right: 0, bottom: 0, height: 1, backgroundColor: colors.border },
   tabActiveBar: { position: 'absolute', bottom: 0, width: '50%', height: 2, backgroundColor: colors.primary, borderRadius: 1 },
+  tabActivity: { left: 0 },
+  tabNotice: { left: '50%' },
   loading: { marginTop: 28 },
   card: { paddingHorizontal: 20, paddingTop: 16, paddingBottom: 20, borderBottomWidth: StyleSheet.hairlineWidth, borderBottomColor: colors.border },
   unreadCard: { backgroundColor: '#FAF9FF' },


### PR DESCRIPTION
## 변경 내용

- 운영자 전용 사용자 의견 목록·상세·답장 API와 관리 화면을 추가했습니다.
- 답장과 사용자 공지 알림을 하나의 트랜잭션으로 저장합니다.
- 사용자 피드백 내역과 공지 탭에서 개발자 답장을 확인할 수 있습니다.
- 운영 데이터와 피드백 조회 실패를 분리해 한 기능의 오류가 다른 관리 기능을 막지 않도록 했습니다.
- 환경변수 기반 운영자 계정 프로비저닝 절차를 추가했습니다.

## 수정 파일

| 파일 | 변경 이유 |
| --- | --- |
| `server/server.js` | 운영자 피드백 API, 알림 스키마 호환, 라우트 연결 |
| `server/feedback/service.js` | 답장 정규화·조회 결합·트랜잭션 처리 |
| `server/auth/adminAuthorization.js` | 운영자 권한 검증 분리 |
| `server/scripts/provisionAdmin.js` | 환경변수 기반 운영자 계정 준비 |
| `server/lib/test/*.tests.js` | 권한·답장·알림·롤백 회귀 테스트 |
| `src/screens/AdminScreen.tsx` | 사용자 의견 목록·상세·답장 UI |
| `src/screens/DeveloperFeedbackScreen.tsx` | 사용자 답장 내역 표시 |
| `src/screens/NotificationScreen.tsx` | 공지 탭 개발자 답장 알림 표시 |
| `server/package.json`, `server/.env.example` | 운영자 준비 명령과 설정 항목 |

## 검증

- [x] `npx tsc --noEmit`
- [x] 변경 파일 ESLint 오류·경고 0건
- [x] 앱 Jest 2개 스위트, 4개 테스트 통과
- [x] 서버 52개 테스트 통과
- [x] 서버 JavaScript 구문 검사 통과
- [x] `git diff --check` 통과
- [x] 변경분 민감정보 패턴 검사 통과

## 연결 이슈

Closes #53