### PR TITLE
feat(activity): 기존 목표 기반 학습 로드맵 적용

### DIFF
--- a/server/lib/learningRoadmap.js
+++ b/server/lib/learningRoadmap.js
@@ -1,0 +1,358 @@
+const ROADMAP_SOURCE = 'EXISTING_TODOS';
+const VALID_STATUSES = new Set(['미진행', '진행중', '완료']);
+const STATUS_SCORES = {
+  미진행: 0,
+  진행중: 0.5,
+  완료: 1,
+};
+const SCOPE_ORDER = {
+  월간: 0,
+  주간: 1,
+  일일: 2,
+  전체: 3,
+};
+
+const pad = (value) => String(value).padStart(2, '0');
+
+const formatLocalDate = (date) => (
+  `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}`
+);
+
+const isValidDateKey = (value) => {
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+  const [year, month, day] = value.split('-').map(Number);
+  const date = new Date(Date.UTC(year, month - 1, day));
+  return date.getUTCFullYear() === year
+    && date.getUTCMonth() === month - 1
+    && date.getUTCDate() === day;
+};
+
+const toDateKey = (value) => {
+  if (!value) return null;
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime()) ? null : formatLocalDate(value);
+  }
+
+  const candidate = String(value).slice(0, 10);
+  return isValidDateKey(candidate) ? candidate : null;
+};
+
+const toDayNumber = (dateKey) => {
+  const [year, month, day] = dateKey.split('-').map(Number);
+  return Math.floor(Date.UTC(year, month - 1, day) / 86400000);
+};
+
+const fromDayNumber = (dayNumber) => {
+  const date = new Date(dayNumber * 86400000);
+  return `${date.getUTCFullYear()}-${pad(date.getUTCMonth() + 1)}-${pad(date.getUTCDate())}`;
+};
+
+const clampTitle = (value, fallback = '이름 없는 목표') => {
+  const title = String(value || '').trim();
+  return (title || fallback).slice(0, 120);
+};
+
+const normalizeTodo = (todo, index) => {
+  const startDate = toDateKey(todo?.scope_start_date);
+  const endDate = toDateKey(todo?.scope_end_date) || startDate;
+  const normalizedStart = startDate && endDate && startDate > endDate ? endDate : startDate;
+  const normalizedEnd = startDate && endDate && startDate > endDate ? startDate : endDate;
+  const scopeType = Object.prototype.hasOwnProperty.call(SCOPE_ORDER, todo?.scope_type)
+    ? todo.scope_type
+    : '전체';
+  const status = VALID_STATUSES.has(todo?.status) ? todo.status : '미진행';
+  const numericId = Number(todo?.todo_id);
+
+  return {
+    todo_id: Number.isInteger(numericId) && numericId > 0 ? numericId : `generated-${index}`,
+    title: clampTitle(todo?.title),
+    status,
+    scope_type: scopeType,
+    scope_start_date: normalizedStart,
+    scope_end_date: normalizedEnd,
+  };
+};
+
+const compareTodos = (first, second) => (
+  (first.scope_start_date || '9999-12-31').localeCompare(second.scope_start_date || '9999-12-31')
+  || (SCOPE_ORDER[first.scope_type] ?? 99) - (SCOPE_ORDER[second.scope_type] ?? 99)
+  || String(first.todo_id).localeCompare(String(second.todo_id))
+);
+
+const calculateProgress = (todos) => {
+  if (!todos.length) return 0;
+  const score = todos.reduce((total, todo) => total + STATUS_SCORES[todo.status], 0);
+  return Math.round((score / todos.length) * 100);
+};
+
+const summarizeTodos = (todos) => {
+  const summary = {
+    total_count: todos.length,
+    completed_count: 0,
+    in_progress_count: 0,
+    pending_count: 0,
+    percent: calculateProgress(todos),
+  };
+
+  todos.forEach((todo) => {
+    if (todo.status === '완료') summary.completed_count += 1;
+    else if (todo.status === '진행중') summary.in_progress_count += 1;
+    else summary.pending_count += 1;
+  });
+
+  return summary;
+};
+
+const getWeekRange = (dateKey) => {
+  const dayNumber = toDayNumber(dateKey);
+  const weekday = new Date(dayNumber * 86400000).getUTCDay();
+  const mondayOffset = (weekday + 6) % 7;
+  return {
+    start_date: fromDayNumber(dayNumber - mondayOffset),
+    end_date: fromDayNumber(dayNumber - mondayOffset + 6),
+  };
+};
+
+const rangesOverlap = (first, second) => (
+  Boolean(first.start_date && first.end_date && second.scope_start_date && second.scope_end_date)
+  && first.start_date <= second.scope_end_date
+  && first.end_date >= second.scope_start_date
+);
+
+const overlapDays = (segment, todo) => {
+  if (!rangesOverlap(segment, todo)) return 0;
+  const start = Math.max(toDayNumber(segment.start_date), toDayNumber(todo.scope_start_date));
+  const end = Math.min(toDayNumber(segment.end_date), toDayNumber(todo.scope_end_date));
+  return end - start + 1;
+};
+
+const groupAnchors = (anchors, sourceScope) => {
+  const byRange = new Map();
+
+  anchors.forEach((todo) => {
+    const range = todo.scope_start_date && todo.scope_end_date
+      ? { start_date: todo.scope_start_date, end_date: todo.scope_end_date }
+      : { start_date: null, end_date: null };
+    const key = `${range.start_date || 'undated'}:${range.end_date || 'undated'}`;
+    const current = byRange.get(key) || {
+      id: `${sourceScope === '주간' ? 'weekly' : 'monthly'}:${key}`,
+      source_scope_type: sourceScope,
+      start_date: range.start_date,
+      end_date: range.end_date,
+      anchor_todos: [],
+      todos: [],
+    };
+    current.anchor_todos.push(todo);
+    current.todos.push(todo);
+    byRange.set(key, current);
+  });
+
+  return [...byRange.values()];
+};
+
+const buildDerivedSegment = (todo) => {
+  if (!todo.scope_start_date) {
+    return {
+      id: 'derived:undated',
+      source_scope_type: '일일',
+      start_date: null,
+      end_date: null,
+      anchor_todos: [],
+      todos: [],
+    };
+  }
+
+  const range = getWeekRange(todo.scope_start_date);
+  return {
+    id: `derived:${range.start_date}:${range.end_date}`,
+    source_scope_type: '일일',
+    ...range,
+    anchor_todos: [],
+    todos: [],
+  };
+};
+
+const findBestSegment = (segments, todo) => {
+  const candidates = segments
+    .map((segment, index) => ({ segment, index, overlap: overlapDays(segment, todo) }))
+    .filter((candidate) => candidate.overlap > 0)
+    .sort((first, second) => (
+      second.overlap - first.overlap
+      || (toDayNumber(first.segment.end_date) - toDayNumber(first.segment.start_date))
+        - (toDayNumber(second.segment.end_date) - toDayNumber(second.segment.start_date))
+      || first.index - second.index
+    ));
+
+  return candidates[0]?.segment || null;
+};
+
+const getSegmentStatus = (segment, today) => {
+  if (segment.summary.total_count > 0 && segment.summary.completed_count === segment.summary.total_count) {
+    return '완료';
+  }
+  if (segment.end_date && segment.end_date < today) return '지연';
+  if (segment.start_date && segment.start_date > today) return '예정';
+  if (segment.summary.in_progress_count > 0 || segment.summary.completed_count > 0) return '진행중';
+  if (segment.start_date && segment.end_date && segment.start_date <= today && segment.end_date >= today) {
+    return '진행중';
+  }
+  return '미진행';
+};
+
+const finalizeSegments = (segments, today) => segments
+  .map((segment) => {
+    const todos = [...segment.todos].sort(compareTodos);
+    const anchorTitles = segment.anchor_todos.map((todo) => todo.title);
+    const fallbackDate = segment.start_date
+      ? `${Number(segment.start_date.slice(5, 7))}월 ${Number(segment.start_date.slice(8, 10))}일 주차`
+      : '기간 미정 목표';
+    const title = anchorTitles.length > 1
+      ? `${anchorTitles[0]} 외 ${anchorTitles.length - 1}개`
+      : anchorTitles[0] || fallbackDate;
+    const summary = summarizeTodos(todos);
+    const next = {
+      id: segment.id,
+      title,
+      source_scope_type: segment.source_scope_type,
+      start_date: segment.start_date,
+      end_date: segment.end_date,
+      status: '미진행',
+      summary,
+      todos,
+    };
+    next.status = getSegmentStatus(next, today);
+    return next;
+  })
+  .sort((first, second) => (
+    (first.start_date || '9999-12-31').localeCompare(second.start_date || '9999-12-31')
+    || first.title.localeCompare(second.title, 'ko')
+  ));
+
+const findCurrentSegmentIndex = (segments, today) => {
+  const activeIndex = segments.findIndex((segment) => (
+    segment.status !== '완료'
+    && segment.start_date
+    && segment.end_date
+    && segment.start_date <= today
+    && segment.end_date >= today
+  ));
+  if (activeIndex >= 0) return activeIndex;
+
+  const upcomingIndex = segments.findIndex((segment) => (
+    segment.status !== '완료' && segment.start_date && segment.start_date > today
+  ));
+  if (upcomingIndex >= 0) return upcomingIndex;
+
+  for (let index = segments.length - 1; index >= 0; index -= 1) {
+    if (segments[index].status !== '완료') return index;
+  }
+
+  return segments.length ? segments.length - 1 : -1;
+};
+
+const buildLearningRoadmap = ({
+  teamId = null,
+  teamName = '',
+  activityStartDate = null,
+  activityEndDate = null,
+  today = formatLocalDate(new Date()),
+  todos = [],
+} = {}) => {
+  const todayKey = toDateKey(today) || formatLocalDate(new Date());
+  const uniqueTodos = new Map();
+  (Array.isArray(todos) ? todos : []).forEach((todo, index) => {
+    const normalized = normalizeTodo(todo, index);
+    uniqueTodos.set(String(normalized.todo_id), normalized);
+  });
+  const normalizedTodos = [...uniqueTodos.values()].sort(compareTodos);
+  const monthlyTodos = normalizedTodos.filter((todo) => todo.scope_type === '월간');
+  const weeklyTodos = normalizedTodos.filter((todo) => todo.scope_type === '주간');
+  const dailyTodos = normalizedTodos.filter((todo) => todo.scope_type === '일일');
+  const otherTodos = normalizedTodos.filter((todo) => todo.scope_type === '전체');
+
+  let segments = weeklyTodos.length
+    ? groupAnchors(weeklyTodos, '주간')
+    : monthlyTodos.length
+      ? groupAnchors(monthlyTodos, '월간')
+      : [];
+
+  const assignedTodoIds = new Set(segments.flatMap((segment) => segment.todos.map((todo) => String(todo.todo_id))));
+  const childTodos = [...dailyTodos, ...otherTodos];
+
+  childTodos.forEach((todo) => {
+    if (assignedTodoIds.has(String(todo.todo_id))) return;
+    let segment = findBestSegment(segments, todo);
+    if (!segment) {
+      const derived = buildDerivedSegment(todo);
+      segment = segments.find((candidate) => candidate.id === derived.id);
+      if (!segment) {
+        segment = derived;
+        segments.push(segment);
+      }
+    }
+    segment.todos.push(todo);
+    assignedTodoIds.add(String(todo.todo_id));
+  });
+
+  if (!segments.length && normalizedTodos.length) {
+    normalizedTodos.forEach((todo) => {
+      const derived = buildDerivedSegment(todo);
+      let segment = segments.find((candidate) => candidate.id === derived.id);
+      if (!segment) {
+        segment = derived;
+        segments.push(segment);
+      }
+      segment.todos.push(todo);
+    });
+  }
+
+  segments = finalizeSegments(segments, todayKey);
+  const currentIndex = findCurrentSegmentIndex(segments, todayKey);
+  const currentSegment = currentIndex >= 0 ? segments[currentIndex] : null;
+  const nextSegment = currentIndex >= 0
+    ? segments.slice(currentIndex + 1).find((segment) => segment.status !== '완료') || null
+    : null;
+  const activeMilestone = monthlyTodos.find((todo) => (
+    todo.status !== '완료'
+    && todo.scope_start_date
+    && todo.scope_end_date
+    && todo.scope_start_date <= todayKey
+    && todo.scope_end_date >= todayKey
+  )) || monthlyTodos.find((todo) => todo.status !== '완료') || monthlyTodos[0];
+  const validStarts = normalizedTodos.map((todo) => todo.scope_start_date).filter(Boolean);
+  const validEnds = normalizedTodos.map((todo) => todo.scope_end_date).filter(Boolean);
+  const fallbackStart = toDateKey(activityStartDate);
+  const fallbackEnd = toDateKey(activityEndDate);
+  const summary = summarizeTodos(normalizedTodos);
+
+  return {
+    team_id: Number.isInteger(Number(teamId)) ? Number(teamId) : null,
+    title: activeMilestone?.title || `${clampTitle(teamName, '현재 활동')} 학습 로드맵`,
+    source: ROADMAP_SOURCE,
+    is_generated: true,
+    period: {
+      start_date: validStarts.length ? validStarts.sort()[0] : fallbackStart,
+      end_date: validEnds.length ? validEnds.sort().at(-1) : fallbackEnd,
+    },
+    summary,
+    today_remaining_count: normalizedTodos.filter((todo) => (
+      todo.status !== '완료'
+      && todo.scope_start_date
+      && todo.scope_end_date
+      && todo.scope_start_date <= todayKey
+      && todo.scope_end_date >= todayKey
+    )).length,
+    milestones: monthlyTodos,
+    current_segment_id: currentSegment?.id || null,
+    current_segment: currentSegment,
+    next_segment: nextSegment,
+    segments,
+  };
+};
+
+module.exports = {
+  ROADMAP_SOURCE,
+  buildLearningRoadmap,
+  calculateProgress,
+  toDateKey,
+};

--- a/server/lib/learningRoadmap.js
+++ b/server/lib/learningRoadmap.js
@@ -113,6 +113,15 @@ const getWeekRange = (dateKey) => {
   };
 };
 
+const getWeekOfMonthTitle = (dateKey) => {
+  if (!dateKey) return '기간 미정 목표';
+  const [year, month, day] = dateKey.split('-').map(Number);
+  const firstWeekday = new Date(Date.UTC(year, month - 1, 1)).getUTCDay();
+  const mondayOffset = (firstWeekday + 6) % 7;
+  const weekOfMonth = Math.ceil((day + mondayOffset) / 7);
+  return `${month}월 ${weekOfMonth}주차`;
+};
+
 const rangesOverlap = (first, second) => (
   Boolean(first.start_date && first.end_date && second.scope_start_date && second.scope_end_date)
   && first.start_date <= second.scope_end_date
@@ -203,9 +212,7 @@ const finalizeSegments = (segments, today) => segments
   .map((segment) => {
     const todos = [...segment.todos].sort(compareTodos);
     const anchorTitles = segment.anchor_todos.map((todo) => todo.title);
-    const fallbackDate = segment.start_date
-      ? `${Number(segment.start_date.slice(5, 7))}월 ${Number(segment.start_date.slice(8, 10))}일 주차`
-      : '기간 미정 목표';
+    const fallbackDate = getWeekOfMonthTitle(segment.start_date);
     const title = anchorTitles.length > 1
       ? `${anchorTitles[0]} 외 ${anchorTitles.length - 1}개`
       : anchorTitles[0] || fallbackDate;

--- a/server/lib/test/learningRoadmap.tests.js
+++ b/server/lib/test/learningRoadmap.tests.js
@@ -92,10 +92,40 @@ test('주간과 월간 목표가 없으면 일일 목표를 주차별로 묶는�
   });
 
   assert.equal(roadmap.segments.length, 2);
+  assert.equal(roadmap.segments[0].title, '8월 3주차');
   assert.equal(roadmap.segments[0].start_date, '2026-08-10');
   assert.equal(roadmap.segments[0].end_date, '2026-08-16');
+  assert.equal(roadmap.segments[1].title, '8월 4주차');
   assert.equal(roadmap.segments[1].start_date, '2026-08-17');
   assert.equal(roadmap.current_segment_id, 'derived:2026-08-17:2026-08-23');
+});
+
+test('사용자가 설정한 구간명과 기간을 기본 주차명보다 우선한다', () => {
+  const roadmap = buildLearningRoadmap({
+    today: '2026-08-12',
+    todos: [
+      {
+        todo_id: 15,
+        title: '핵심 기능 설계 기간',
+        status: '진행중',
+        scope_type: '주간',
+        scope_start_date: '2026-08-11',
+        scope_end_date: '2026-08-20',
+      },
+      {
+        todo_id: 16,
+        title: '화면 흐름 정리',
+        status: '미진행',
+        scope_type: '일일',
+        scope_start_date: '2026-08-13',
+        scope_end_date: '2026-08-13',
+      },
+    ],
+  });
+
+  assert.equal(roadmap.segments[0].title, '핵심 기능 설계 기간');
+  assert.equal(roadmap.segments[0].start_date, '2026-08-11');
+  assert.equal(roadmap.segments[0].end_date, '2026-08-20');
 });
 
 test('같은 기간의 주간 목표는 하나의 구간으로 합친다', () => {

--- a/server/lib/test/learningRoadmap.tests.js
+++ b/server/lib/test/learningRoadmap.tests.js
@@ -1,0 +1,174 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  buildLearningRoadmap,
+  calculateProgress,
+  toDateKey,
+} = require('../learningRoadmap');
+
+test('진행중 목표를 절반으로 반영해 진행률을 계산한다', () => {
+  const percent = calculateProgress([
+    { status: '완료' },
+    { status: '진행중' },
+    { status: '미진행' },
+    { status: '완료' },
+  ]);
+
+  assert.equal(percent, 63);
+});
+
+test('주간 목표를 구간으로 만들고 같은 기간의 일일 목표를 연결한다', () => {
+  const roadmap = buildLearningRoadmap({
+    teamId: 7,
+    teamName: '데이터 분석 공모전',
+    today: '2026-08-12',
+    todos: [
+      {
+        todo_id: 1,
+        title: '분석 파이프라인 완성',
+        status: '진행중',
+        scope_type: '월간',
+        scope_start_date: '2026-08-01',
+        scope_end_date: '2026-08-31',
+      },
+      {
+        todo_id: 2,
+        title: '데이터 전처리',
+        status: '진행중',
+        scope_type: '주간',
+        scope_start_date: '2026-08-10',
+        scope_end_date: '2026-08-16',
+      },
+      {
+        todo_id: 3,
+        title: '결측치 처리',
+        status: '완료',
+        scope_type: '일일',
+        scope_start_date: '2026-08-11',
+        scope_end_date: '2026-08-11',
+      },
+      {
+        todo_id: 4,
+        title: '이상치 기준 정리',
+        status: '미진행',
+        scope_type: '일일',
+        scope_start_date: '2026-08-13',
+        scope_end_date: '2026-08-13',
+      },
+    ],
+  });
+
+  assert.equal(roadmap.title, '분석 파이프라인 완성');
+  assert.equal(roadmap.segments.length, 1);
+  assert.equal(roadmap.segments[0].title, '데이터 전처리');
+  assert.deepEqual(roadmap.segments[0].todos.map((todo) => todo.todo_id), [2, 3, 4]);
+  assert.equal(roadmap.segments[0].summary.percent, 50);
+  assert.equal(roadmap.current_segment_id, 'weekly:2026-08-10:2026-08-16');
+  assert.equal(roadmap.today_remaining_count, 2);
+});
+
+test('주간과 월간 목표가 없으면 일일 목표를 주차별로 묶는다', () => {
+  const roadmap = buildLearningRoadmap({
+    teamName: '알고리즘 스터디',
+    today: '2026-08-12',
+    todos: [
+      {
+        todo_id: 11,
+        title: '그래프 문제 풀이',
+        status: '완료',
+        scope_type: '일일',
+        scope_start_date: '2026-08-10',
+        scope_end_date: '2026-08-10',
+      },
+      {
+        todo_id: 12,
+        title: 'DP 문제 풀이',
+        status: '미진행',
+        scope_type: '일일',
+        scope_start_date: '2026-08-17',
+        scope_end_date: '2026-08-17',
+      },
+    ],
+  });
+
+  assert.equal(roadmap.segments.length, 2);
+  assert.equal(roadmap.segments[0].start_date, '2026-08-10');
+  assert.equal(roadmap.segments[0].end_date, '2026-08-16');
+  assert.equal(roadmap.segments[1].start_date, '2026-08-17');
+  assert.equal(roadmap.current_segment_id, 'derived:2026-08-17:2026-08-23');
+});
+
+test('같은 기간의 주간 목표는 하나의 구간으로 합친다', () => {
+  const roadmap = buildLearningRoadmap({
+    today: '2026-08-05',
+    todos: [
+      {
+        todo_id: 21,
+        title: '기획안 작성',
+        status: '미진행',
+        scope_type: '주간',
+        scope_start_date: '2026-08-03',
+        scope_end_date: '2026-08-09',
+      },
+      {
+        todo_id: 22,
+        title: '자료 조사',
+        status: '완료',
+        scope_type: '주간',
+        scope_start_date: '2026-08-03',
+        scope_end_date: '2026-08-09',
+      },
+    ],
+  });
+
+  assert.equal(roadmap.segments.length, 1);
+  assert.equal(roadmap.segments[0].title, '기획안 작성 외 1개');
+  assert.equal(roadmap.segments[0].summary.percent, 50);
+});
+
+test('완료되지 않은 미래 구간을 현재 구간으로 선택한다', () => {
+  const roadmap = buildLearningRoadmap({
+    today: '2026-08-15',
+    todos: [
+      {
+        todo_id: 31,
+        title: '1주차',
+        status: '완료',
+        scope_type: '주간',
+        scope_start_date: '2026-08-03',
+        scope_end_date: '2026-08-09',
+      },
+      {
+        todo_id: 32,
+        title: '3주차',
+        status: '미진행',
+        scope_type: '주간',
+        scope_start_date: '2026-08-17',
+        scope_end_date: '2026-08-23',
+      },
+    ],
+  });
+
+  assert.equal(roadmap.current_segment.title, '3주차');
+  assert.equal(roadmap.current_segment.status, '예정');
+});
+
+test('잘못된 날짜와 빈 목표 목록을 안전하게 처리한다', () => {
+  assert.equal(toDateKey('2026-02-31'), null);
+  assert.equal(toDateKey('not-a-date'), null);
+
+  const roadmap = buildLearningRoadmap({
+    teamName: '선형대수학 학습 공동체',
+    activityStartDate: '2026-08-01',
+    activityEndDate: '2026-10-31',
+    todos: [],
+  });
+
+  assert.equal(roadmap.title, '선형대수학 학습 공동체 학습 로드맵');
+  assert.equal(roadmap.summary.total_count, 0);
+  assert.deepEqual(roadmap.segments, []);
+  assert.deepEqual(roadmap.period, {
+    start_date: '2026-08-01',
+    end_date: '2026-10-31',
+  });
+});

--- a/server/server.js
+++ b/server/server.js
@@ -21,6 +21,7 @@ const { createSecureImageUpload } = require('./lib/secureImageUpload');
 const { createTtlCache } = require('./lib/ttlCache');
 const { extractPrizeDetails, extractPrizeSummary } = require('./lib/activityPrize');
 const { buildMonthTodoCalendar, findPeriodGoalCapacityConflict } = require('./lib/todoCalendar');
+const { buildLearningRoadmap } = require('./lib/learningRoadmap');
 const {
   ensureAwardsSchema,
   listAwards,
@@ -3188,6 +3189,56 @@ app.get('/teams/:teamId/progress', (req, res) => {
       });
     });
   });
+});
+
+app.get('/teams/:teamId/learning-roadmap', async (req, res) => {
+  const userId = getRequestUserId(req);
+  const teamId = Number(req.params.teamId);
+
+  if (!userId) return res.status(401).json({ message: '로그인이 필요합니다' });
+  if (!Number.isInteger(teamId) || teamId <= 0) {
+    return res.status(400).json({ message: '활동 정보가 올바르지 않습니다' });
+  }
+
+  try {
+    const [teams] = await portfolioDb.query(
+      `SELECT t.team_id, t.team_name, t.created_at, t.due_date
+       FROM teams t
+       JOIN team_members tm ON tm.team_id = t.team_id
+       WHERE t.team_id = ?
+         AND tm.user_id = ?
+         AND t.activity_status = 'IN_PROGRESS'
+         AND t.status <> 'ARCHIVED'
+       LIMIT 1`,
+      [teamId, userId],
+    );
+
+    if (!teams.length) {
+      return res.status(404).json({ message: '진행 중인 활동을 찾을 수 없습니다' });
+    }
+
+    const [todos] = await portfolioDb.query(
+      `SELECT todo_id, title, status, scope_type, scope_start_date, scope_end_date
+       FROM todos
+       WHERE team_id = ?
+         AND assigned_user_id = ?
+       ORDER BY scope_start_date ASC, todo_id ASC
+       LIMIT 5000`,
+      [teamId, userId],
+    );
+    const team = teams[0];
+
+    res.json(buildLearningRoadmap({
+      teamId,
+      teamName: team.team_name,
+      activityStartDate: team.created_at,
+      activityEndDate: team.due_date,
+      todos,
+    }));
+  } catch (error) {
+    console.error('학습 로드맵 조회 오류:', error);
+    res.status(500).json({ message: '학습 로드맵을 불러오지 못했습니다' });
+  }
 });
 
 app.get('/teams/:teamId/daily-todos', (req, res) => {

--- a/src/Widget/LearningRoadmap.tsx
+++ b/src/Widget/LearningRoadmap.tsx
@@ -1,0 +1,534 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import Icon from 'react-native-vector-icons/Ionicons';
+import colors from '../config/colors';
+import { useAuth } from '../context/AuthContext';
+import type { RootStackParamList } from '../types';
+
+type Props = {
+  teamId?: number | null;
+  refreshKey?: number;
+};
+
+type RoadmapTodo = {
+  todo_id: number | string;
+  title: string;
+  status: '미진행' | '진행중' | '완료';
+  scope_type: '월간' | '주간' | '일일' | '전체';
+};
+
+type RoadmapSummary = {
+  total_count: number;
+  completed_count: number;
+  in_progress_count: number;
+  pending_count: number;
+  percent: number;
+};
+
+type RoadmapSegment = {
+  id: string;
+  title: string;
+  start_date: string | null;
+  end_date: string | null;
+  status: '미진행' | '진행중' | '완료' | '예정' | '지연';
+  summary: RoadmapSummary;
+  todos: RoadmapTodo[];
+};
+
+type LearningRoadmapData = {
+  team_id: number;
+  title: string;
+  is_generated: boolean;
+  summary: RoadmapSummary;
+  today_remaining_count: number;
+  current_segment_id: string | null;
+  current_segment: RoadmapSegment | null;
+  next_segment: RoadmapSegment | null;
+  segments: RoadmapSegment[];
+};
+
+type Navigation = NativeStackNavigationProp<RootStackParamList>;
+
+const API_BASE_URL = __DEV__
+  ? (Platform.OS === 'android' ? 'http://10.0.2.2:3000' : 'http://localhost:3000')
+  : 'https://your.api';
+
+const statusColors: Record<RoadmapSegment['status'], { background: string; text: string }> = {
+  미진행: { background: '#F2F4F7', text: '#667085' },
+  진행중: { background: colors.primarySurface, text: colors.primaryDark },
+  완료: { background: '#ECFDF3', text: '#027A48' },
+  예정: { background: '#EFF8FF', text: '#175CD3' },
+  지연: { background: '#FEF3F2', text: '#B42318' },
+};
+
+function formatDateRange(startDate: string | null, endDate: string | null) {
+  if (!startDate && !endDate) return '기간 미정';
+  const compact = (value: string) => {
+    const [, month, day] = value.split('-');
+    return `${Number(month)}.${Number(day)}`;
+  };
+  if (!startDate) return `~ ${compact(endDate as string)}`;
+  if (!endDate || startDate === endDate) return compact(startDate);
+  return `${compact(startDate)} - ${compact(endDate)}`;
+}
+
+function getVisibleSegments(data: LearningRoadmapData) {
+  if (data.segments.length <= 3) return data.segments;
+  const currentIndex = data.segments.findIndex((segment) => segment.id === data.current_segment_id);
+  const startIndex = Math.min(Math.max(currentIndex - 1, 0), data.segments.length - 3);
+  return data.segments.slice(startIndex, startIndex + 3);
+}
+
+export default function LearningRoadmap({ teamId, refreshKey }: Props) {
+  const { user } = useAuth();
+  const navigation = useNavigation<Navigation>();
+  const [data, setData] = useState<LearningRoadmapData | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(false);
+
+  const fetchRoadmap = useCallback(async () => {
+    if (!teamId || !user?.id) {
+      setData(null);
+      setError(false);
+      return;
+    }
+
+    setLoading(true);
+    try {
+      const response = await fetch(`${API_BASE_URL}/teams/${teamId}/learning-roadmap`, {
+        headers: { 'x-user-id': String(user.id) },
+      });
+      if (!response.ok) throw new Error(`학습 로드맵 조회 실패 (${response.status})`);
+      const payload = await response.json();
+      setData(payload && Array.isArray(payload.segments) ? payload : null);
+      setError(false);
+    } catch (fetchError) {
+      setData(null);
+      setError(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [teamId, user?.id]);
+
+  useEffect(() => {
+    fetchRoadmap();
+  }, [fetchRoadmap, refreshKey]);
+
+  const visibleSegments = useMemo(() => data ? getVisibleSegments(data) : [], [data]);
+  const hiddenSegmentCount = data ? Math.max(data.segments.length - visibleSegments.length, 0) : 0;
+
+  if (!teamId) return null;
+
+  return (
+    <View style={styles.wrap}>
+      <View style={styles.headingRow}>
+        <View>
+          <Text style={styles.eyebrow}>STUDY PILOT LOGIC</Text>
+          <Text style={styles.heading}>학습 로드맵</Text>
+        </View>
+        <View style={styles.autoBadge}>
+          <Icon name="sparkles" size={13} color={colors.primaryDark} />
+          <Text style={styles.autoBadgeText}>자동 구성</Text>
+        </View>
+      </View>
+
+      <View style={styles.card}>
+        {loading && !data ? (
+          <View style={styles.stateBox}>
+            <ActivityIndicator color={colors.primary} />
+            <Text style={styles.stateText}>기존 목표로 로드맵을 구성하고 있어요</Text>
+          </View>
+        ) : error ? (
+          <View style={styles.stateBox}>
+            <View style={styles.stateIcon}>
+              <Icon name="cloud-offline-outline" size={22} color={colors.primary} />
+            </View>
+            <Text style={styles.stateTitle}>로드맵을 불러오지 못했어요</Text>
+            <Pressable
+              accessibilityRole="button"
+              onPress={fetchRoadmap}
+              style={({ pressed }) => [styles.retryButton, pressed && styles.pressed]}
+            >
+              <Text style={styles.retryText}>다시 시도</Text>
+            </Pressable>
+          </View>
+        ) : !data || data.summary.total_count === 0 ? (
+          <View style={styles.stateBox}>
+            <View style={styles.stateIcon}>
+              <Icon name="map-outline" size={23} color={colors.primary} />
+            </View>
+            <Text style={styles.stateTitle}>아직 구성할 목표가 없어요</Text>
+            <Text style={styles.stateText}>주간 또는 일일 목표를 추가하면 학습 순서를 자동으로 보여드려요.</Text>
+            <Pressable
+              accessibilityRole="button"
+              onPress={() => navigation.navigate('TodoScreen', { teamId })}
+              style={({ pressed }) => [styles.primaryButton, pressed && styles.pressed]}
+            >
+              <Icon name="add" size={17} color="#FFFFFF" />
+              <Text style={styles.primaryButtonText}>목표 추가</Text>
+            </Pressable>
+          </View>
+        ) : (
+          <>
+            <Text style={styles.roadmapTitle} numberOfLines={2}>{data.title}</Text>
+            <View style={styles.metricsRow}>
+              <View style={styles.metricItem}>
+                <Text style={styles.metricValue}>{data.summary.percent}%</Text>
+                <Text style={styles.metricLabel}>전체 진행률</Text>
+              </View>
+              <View style={styles.metricDivider} />
+              <View style={styles.metricItem}>
+                <Text style={styles.metricValue}>{data.summary.completed_count}</Text>
+                <Text style={styles.metricLabel}>완료 목표</Text>
+              </View>
+              <View style={styles.metricDivider} />
+              <View style={styles.metricItem}>
+                <Text style={styles.metricValue}>{data.today_remaining_count}</Text>
+                <Text style={styles.metricLabel}>오늘 진행</Text>
+              </View>
+            </View>
+
+            <View style={styles.progressTrack}>
+              <View style={[styles.progressFill, { width: `${data.summary.percent}%` }]} />
+            </View>
+
+            <View style={styles.timeline}>
+              {visibleSegments.map((segment, index) => {
+                const isCurrent = segment.id === data.current_segment_id;
+                const palette = statusColors[segment.status];
+                return (
+                  <View key={segment.id} style={styles.segmentRow}>
+                    <View style={styles.timelineRail}>
+                      <View style={[
+                        styles.timelineDot,
+                        isCurrent && styles.timelineDotCurrent,
+                        segment.status === '완료' && styles.timelineDotDone,
+                      ]}>
+                        {segment.status === '완료' ? (
+                          <Icon name="checkmark" size={11} color="#FFFFFF" />
+                        ) : isCurrent ? (
+                          <View style={styles.timelineDotCenter} />
+                        ) : null}
+                      </View>
+                      {index < visibleSegments.length - 1 && <View style={styles.timelineLine} />}
+                    </View>
+                    <View style={[styles.segmentCard, isCurrent && styles.segmentCardCurrent]}>
+                      <View style={styles.segmentHeader}>
+                        <Text style={[styles.segmentTitle, isCurrent && styles.segmentTitleCurrent]} numberOfLines={1}>
+                          {segment.title}
+                        </Text>
+                        <View style={[styles.statusBadge, { backgroundColor: palette.background }]}>
+                          <Text style={[styles.statusText, { color: palette.text }]}>{segment.status}</Text>
+                        </View>
+                      </View>
+                      <View style={styles.segmentMetaRow}>
+                        <Text style={styles.segmentMeta}>
+                          {formatDateRange(segment.start_date, segment.end_date)}
+                        </Text>
+                        <Text style={styles.segmentMeta}>
+                          {segment.summary.completed_count}/{segment.summary.total_count} 완료
+                        </Text>
+                        <Text style={styles.segmentPercent}>{segment.summary.percent}%</Text>
+                      </View>
+                    </View>
+                  </View>
+                );
+              })}
+            </View>
+
+            {hiddenSegmentCount > 0 && (
+              <Text style={styles.moreSegments}>전체 {data.segments.length}개 구간 중 현재 주변 구간을 표시했어요.</Text>
+            )}
+
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="목표 관리 화면으로 이동"
+              onPress={() => navigation.navigate('TodoScreen', { teamId })}
+              style={({ pressed }) => [styles.manageButton, pressed && styles.pressed]}
+            >
+              <Text style={styles.manageButtonText}>목표에서 관리</Text>
+              <Icon name="arrow-forward" size={16} color={colors.primaryDark} />
+            </Pressable>
+          </>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  wrap: {
+    marginBottom: 28,
+  },
+  headingRow: {
+    marginBottom: 12,
+    flexDirection: 'row',
+    alignItems: 'flex-end',
+    justifyContent: 'space-between',
+  },
+  eyebrow: {
+    marginBottom: 3,
+    color: colors.primary,
+    fontSize: 10,
+    fontWeight: '900',
+    letterSpacing: 0.8,
+  },
+  heading: {
+    color: colors.textMain,
+    fontSize: 24,
+    fontWeight: '900',
+  },
+  autoBadge: {
+    paddingHorizontal: 10,
+    paddingVertical: 7,
+    borderRadius: 999,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    backgroundColor: colors.primarySurface,
+  },
+  autoBadgeText: {
+    color: colors.primaryDark,
+    fontSize: 11,
+    fontWeight: '800',
+  },
+  card: {
+    padding: 18,
+    borderWidth: 1,
+    borderColor: '#E9E4FC',
+    borderRadius: 24,
+    backgroundColor: '#FCFBFF',
+    shadowColor: '#4C1D95',
+    shadowOpacity: 0.06,
+    shadowRadius: 14,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 2,
+  },
+  stateBox: {
+    minHeight: 160,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 18,
+  },
+  stateIcon: {
+    width: 48,
+    height: 48,
+    marginBottom: 12,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: colors.primarySurface,
+  },
+  stateTitle: {
+    color: colors.textMain,
+    fontSize: 16,
+    fontWeight: '800',
+    textAlign: 'center',
+  },
+  stateText: {
+    marginTop: 7,
+    color: colors.textSub,
+    fontSize: 13,
+    lineHeight: 19,
+    textAlign: 'center',
+  },
+  retryButton: {
+    marginTop: 13,
+    paddingHorizontal: 15,
+    paddingVertical: 9,
+    borderRadius: 12,
+    backgroundColor: colors.primarySurface,
+  },
+  retryText: {
+    color: colors.primaryDark,
+    fontSize: 13,
+    fontWeight: '800',
+  },
+  primaryButton: {
+    marginTop: 16,
+    paddingHorizontal: 16,
+    paddingVertical: 11,
+    borderRadius: 14,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 5,
+    backgroundColor: colors.primary,
+  },
+  primaryButtonText: {
+    color: '#FFFFFF',
+    fontSize: 13,
+    fontWeight: '800',
+  },
+  pressed: {
+    opacity: 0.72,
+  },
+  roadmapTitle: {
+    color: colors.textMain,
+    fontSize: 18,
+    lineHeight: 25,
+    fontWeight: '900',
+  },
+  metricsRow: {
+    marginTop: 18,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  metricItem: {
+    flex: 1,
+    alignItems: 'center',
+  },
+  metricDivider: {
+    width: 1,
+    height: 27,
+    backgroundColor: colors.border,
+  },
+  metricValue: {
+    color: colors.primaryDark,
+    fontSize: 20,
+    fontWeight: '900',
+  },
+  metricLabel: {
+    marginTop: 3,
+    color: colors.textSub,
+    fontSize: 10,
+    fontWeight: '700',
+  },
+  progressTrack: {
+    height: 8,
+    marginTop: 17,
+    borderRadius: 999,
+    overflow: 'hidden',
+    backgroundColor: '#ECE8F8',
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: 999,
+    backgroundColor: colors.primary,
+  },
+  timeline: {
+    marginTop: 20,
+  },
+  segmentRow: {
+    flexDirection: 'row',
+  },
+  timelineRail: {
+    width: 24,
+    alignItems: 'center',
+  },
+  timelineDot: {
+    width: 14,
+    height: 14,
+    borderWidth: 2,
+    borderColor: '#D0D5DD',
+    borderRadius: 7,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#FFFFFF',
+    zIndex: 1,
+  },
+  timelineDotCurrent: {
+    borderColor: colors.primary,
+    backgroundColor: colors.primarySurface,
+  },
+  timelineDotCenter: {
+    width: 5,
+    height: 5,
+    borderRadius: 3,
+    backgroundColor: colors.primary,
+  },
+  timelineDotDone: {
+    borderColor: colors.primary,
+    backgroundColor: colors.primary,
+  },
+  timelineLine: {
+    width: 2,
+    flex: 1,
+    minHeight: 62,
+    backgroundColor: '#E4DFF4',
+  },
+  segmentCard: {
+    flex: 1,
+    minHeight: 64,
+    marginLeft: 8,
+    marginBottom: 10,
+    padding: 12,
+    borderRadius: 16,
+    backgroundColor: '#FFFFFF',
+  },
+  segmentCardCurrent: {
+    borderWidth: 1,
+    borderColor: '#D9CEFF',
+    backgroundColor: colors.primarySurface,
+  },
+  segmentHeader: {
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  segmentTitle: {
+    flex: 1,
+    marginRight: 8,
+    color: colors.textMain,
+    fontSize: 14,
+    fontWeight: '800',
+  },
+  segmentTitleCurrent: {
+    color: colors.primaryDark,
+  },
+  statusBadge: {
+    paddingHorizontal: 8,
+    paddingVertical: 4,
+    borderRadius: 999,
+  },
+  statusText: {
+    fontSize: 10,
+    fontWeight: '900',
+  },
+  segmentMetaRow: {
+    marginTop: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+  },
+  segmentMeta: {
+    marginRight: 10,
+    color: colors.textSub,
+    fontSize: 10,
+    fontWeight: '700',
+  },
+  segmentPercent: {
+    marginLeft: 'auto',
+    color: colors.primary,
+    fontSize: 11,
+    fontWeight: '900',
+  },
+  moreSegments: {
+    marginTop: 2,
+    color: colors.textSub,
+    fontSize: 11,
+    lineHeight: 16,
+    textAlign: 'center',
+  },
+  manageButton: {
+    marginTop: 12,
+    paddingTop: 14,
+    borderTopWidth: 1,
+    borderTopColor: '#E9E4FC',
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 6,
+  },
+  manageButtonText: {
+    color: colors.primaryDark,
+    fontSize: 13,
+    fontWeight: '800',
+  },
+});

--- a/src/Widget/LearningRoadmap.tsx
+++ b/src/Widget/LearningRoadmap.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import {
   ActivityIndicator,
   Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   Text,
   View,
@@ -81,13 +82,6 @@ function formatDateRange(startDate: string | null, endDate: string | null) {
   return `${compact(startDate)} - ${compact(endDate)}`;
 }
 
-function getVisibleSegments(data: LearningRoadmapData) {
-  if (data.segments.length <= 3) return data.segments;
-  const currentIndex = data.segments.findIndex((segment) => segment.id === data.current_segment_id);
-  const startIndex = Math.min(Math.max(currentIndex - 1, 0), data.segments.length - 3);
-  return data.segments.slice(startIndex, startIndex + 3);
-}
-
 export default function LearningRoadmap({ teamId, refreshKey }: Props) {
   const { user } = useAuth();
   const navigation = useNavigation<Navigation>();
@@ -123,23 +117,11 @@ export default function LearningRoadmap({ teamId, refreshKey }: Props) {
     fetchRoadmap();
   }, [fetchRoadmap, refreshKey]);
 
-  const visibleSegments = useMemo(() => data ? getVisibleSegments(data) : [], [data]);
-  const hiddenSegmentCount = data ? Math.max(data.segments.length - visibleSegments.length, 0) : 0;
-
   if (!teamId) return null;
 
   return (
     <View style={styles.wrap}>
-      <View style={styles.headingRow}>
-        <View>
-          <Text style={styles.eyebrow}>기존 목표 기반</Text>
-          <Text style={styles.heading}>학습 로드맵</Text>
-        </View>
-        <View style={styles.autoBadge}>
-          <Icon name="sparkles" size={13} color={colors.primaryDark} />
-          <Text style={styles.autoBadgeText}>자동 구성</Text>
-        </View>
-      </View>
+      <Text style={styles.heading}>학습 로드맵</Text>
 
       <View style={styles.card}>
         {loading && !data ? (
@@ -201,8 +183,15 @@ export default function LearningRoadmap({ teamId, refreshKey }: Props) {
               <View style={[styles.progressFill, { width: `${data.summary.percent}%` }]} />
             </View>
 
-            <View style={styles.timeline}>
-              {visibleSegments.map((segment, index) => {
+            <ScrollView
+              accessibilityLabel="학습 로드맵 구간 목록"
+              style={styles.timelineViewport}
+              contentContainerStyle={styles.timeline}
+              nestedScrollEnabled
+              persistentScrollbar
+              showsVerticalScrollIndicator
+            >
+              {data.segments.map((segment, index) => {
                 const isCurrent = segment.id === data.current_segment_id;
                 const palette = statusColors[segment.status];
                 return (
@@ -219,11 +208,11 @@ export default function LearningRoadmap({ teamId, refreshKey }: Props) {
                           <View style={styles.timelineDotCenter} />
                         ) : null}
                       </View>
-                      {index < visibleSegments.length - 1 && <View style={styles.timelineLine} />}
+                      {index < data.segments.length - 1 && <View style={styles.timelineLine} />}
                     </View>
                     <View style={[styles.segmentCard, isCurrent && styles.segmentCardCurrent]}>
                       <View style={styles.segmentHeader}>
-                        <Text style={[styles.segmentTitle, isCurrent && styles.segmentTitleCurrent]} numberOfLines={1}>
+                        <Text style={[styles.segmentTitle, isCurrent && styles.segmentTitleCurrent]} numberOfLines={2}>
                           {segment.title}
                         </Text>
                         <View style={[styles.statusBadge, { backgroundColor: palette.background }]}>
@@ -243,11 +232,7 @@ export default function LearningRoadmap({ teamId, refreshKey }: Props) {
                   </View>
                 );
               })}
-            </View>
-
-            {hiddenSegmentCount > 0 && (
-              <Text style={styles.moreSegments}>전체 {data.segments.length}개 구간 중 현재 주변 구간을 표시했어요.</Text>
-            )}
+            </ScrollView>
 
             <Pressable
               accessibilityRole="button"
@@ -269,37 +254,11 @@ const styles = StyleSheet.create({
   wrap: {
     marginBottom: 28,
   },
-  headingRow: {
-    marginBottom: 12,
-    flexDirection: 'row',
-    alignItems: 'flex-end',
-    justifyContent: 'space-between',
-  },
-  eyebrow: {
-    marginBottom: 3,
-    color: colors.primary,
-    fontSize: 10,
-    fontWeight: '900',
-    letterSpacing: 0.8,
-  },
   heading: {
+    marginBottom: 12,
     color: colors.textMain,
     fontSize: 24,
     fontWeight: '900',
-  },
-  autoBadge: {
-    paddingHorizontal: 10,
-    paddingVertical: 7,
-    borderRadius: 999,
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 5,
-    backgroundColor: colors.primarySurface,
-  },
-  autoBadgeText: {
-    color: colors.primaryDark,
-    fontSize: 11,
-    fontWeight: '800',
   },
   card: {
     padding: 18,
@@ -414,8 +373,13 @@ const styles = StyleSheet.create({
     borderRadius: 999,
     backgroundColor: colors.primary,
   },
-  timeline: {
+  timelineViewport: {
     marginTop: 20,
+    maxHeight: 286,
+  },
+  timeline: {
+    paddingRight: 4,
+    paddingBottom: 2,
   },
   segmentRow: {
     flexDirection: 'row',
@@ -508,13 +472,6 @@ const styles = StyleSheet.create({
     color: colors.primary,
     fontSize: 11,
     fontWeight: '900',
-  },
-  moreSegments: {
-    marginTop: 2,
-    color: colors.textSub,
-    fontSize: 11,
-    lineHeight: 16,
-    textAlign: 'center',
   },
   manageButton: {
     marginTop: 12,

--- a/src/Widget/LearningRoadmap.tsx
+++ b/src/Widget/LearningRoadmap.tsx
@@ -132,7 +132,7 @@ export default function LearningRoadmap({ teamId, refreshKey }: Props) {
     <View style={styles.wrap}>
       <View style={styles.headingRow}>
         <View>
-          <Text style={styles.eyebrow}>STUDY PILOT LOGIC</Text>
+          <Text style={styles.eyebrow}>기존 목표 기반</Text>
           <Text style={styles.heading}>학습 로드맵</Text>
         </View>
         <View style={styles.autoBadge}>

--- a/src/constants/widgets.tsx
+++ b/src/constants/widgets.tsx
@@ -4,13 +4,15 @@ import IssueTracker from '../Widget/IssueTracker';
 import NoticeBoard from '../Widget/NoticeBoard';
 import Heatmap from '../Widget/Heatmap';
 import ActivityCalendar from '../Widget/ActivityCalendar';
+import LearningRoadmap from '../Widget/LearningRoadmap';
 
-export type WidgetId = 'ring' | 'issue' | 'notice' | 'calendar' | 'heatmap';
+export type WidgetId = 'ring' | 'roadmap' | 'issue' | 'notice' | 'calendar' | 'heatmap';
 export type WidgetPref = { id: WidgetId; visible: boolean; order: number };
 export type WidgetComponentProps = { teamId?: number | null; refreshKey?: number };
 
 export const DEFAULT_WIDGET_PREFS: WidgetPref[] = [
   { id: 'ring', visible: true, order: 10 },
+  { id: 'roadmap', visible: true, order: 15 },
   { id: 'issue', visible: true, order: 20 },
   { id: 'notice', visible: true, order: 30 },
   { id: 'calendar', visible: true, order: 40 },
@@ -19,6 +21,7 @@ export const DEFAULT_WIDGET_PREFS: WidgetPref[] = [
 
 // 레지스트리: 이제 각 위젯이 teamId prop을 받을 수 있게 타입 지정
 export const WIDGET_COMPONENTS: Partial<Record<WidgetId, React.FC<WidgetComponentProps>>> = {
+  roadmap: LearningRoadmap,
   issue: IssueTracker,
   notice: NoticeBoard,
   calendar: ActivityCalendar,

--- a/src/screens/ActivitySettingScreen.tsx
+++ b/src/screens/ActivitySettingScreen.tsx
@@ -48,6 +48,11 @@ const WIDGET_META: Record<WidgetId, WidgetMeta> = {
     description: '전체 목표 진행률을 한눈에 확인해요',
     icon: 'stats-chart-outline',
   },
+  roadmap: {
+    title: '학습 로드맵',
+    description: '기존 목표를 학습 구간과 진행 순서로 자동 구성해요',
+    icon: 'map-outline',
+  },
   issue: {
     title: '이슈트래커',
     description: '오늘 진행할 팀 목표를 상태별로 보여줘요',


### PR DESCRIPTION
## 변경 사항
- 기존 월간·주간·일일 목표를 학습 구간으로 자동 구성하는 계산 로직을 추가했습니다.
- 별도 구간 설정이 없으면 월요일 기준 `몇 월 몇 주차`를 기본 구간명으로 표시합니다.
- 사용자가 주간·월간 목표로 직접 설정한 구간명과 시작일·종료일은 기본 주차명보다 우선합니다.
- 모든 로드맵 구간을 위젯 안에서 위아래로 스크롤해 확인할 수 있도록 변경했습니다.
- 학습 로드맵 상단의 보조 문구와 자동 구성 배지를 제거했습니다.
- 로그인 사용자와 진행 중인 팀을 기준으로 학습 로드맵을 조회하는 읽기 전용 API를 추가했습니다.
- 활동 편집에서 로드맵 위젯의 표시 여부와 순서를 변경할 수 있도록 등록했습니다.

## 수정 파일
| 파일 | 내용 |
| --- | --- |
| `server/lib/learningRoadmap.js` | 목표 정규화, 구간화, 진행률 및 주차명 계산 |
| `server/lib/test/learningRoadmap.tests.js` | 계산 로직과 구간명 우선순위 단위 테스트 |
| `server/server.js` | 학습 로드맵 조회 API |
| `src/Widget/LearningRoadmap.tsx` | 활동 탭 로드맵 위젯과 세로 구간 탐색 |
| `src/constants/widgets.tsx` | 위젯 등록과 기본 순서 |
| `src/screens/ActivitySettingScreen.tsx` | 표시·순서 편집 항목 추가 |

## 검증
- 서버 전체 테스트 59건 통과
- 로드맵 단위 테스트 7건 통과
- 앱 Jest 테스트 4건 통과
- TypeScript 타입 검사 통과
- 변경 파일 ESLint 오류 없음
- Android 빌드 및 에뮬레이터 번들 로드 확인
- 정상 사용자, 비로그인, 비멤버 API 응답 확인

## 적용 및 롤백
- DB 스키마 변경 없이 기존 목표 데이터를 읽어 계산합니다.
- 활동 편집에서 위젯을 숨길 수 있습니다.
- 문제가 있으면 이 PR의 커밋을 역순으로 되돌릴 수 있습니다.

Closes #75