### PR TITLE
fix(activity): 선택 활동 팀원과 관리 기능 표시

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -3118,6 +3118,8 @@ app.get('/teams/:teamId/members', (req, res) => {
     SELECT
       u.id AS user_id,
       u.name,
+      u.department,
+      u.profile_picture,
       tm.part,
       tm.role
     FROM team_members requester
@@ -3134,7 +3136,10 @@ app.get('/teams/:teamId/members', (req, res) => {
       return res.status(500).json({ message: '서버 오류' });
     }
 
-    res.json(results || []);
+    res.json((results || []).map((member) => ({
+      ...member,
+      profile_picture: normalizeLocalUrl(member.profile_picture),
+    })));
   });
 });
 

--- a/web/src/pages/ActivityManagePage.tsx
+++ b/web/src/pages/ActivityManagePage.tsx
@@ -1,6 +1,6 @@
 import { AlertCircle, ArrowLeft, Check, Circle, Clock3, Plus, Save, Settings2, Trash2, UserRound, UsersRound } from 'lucide-react';
 import { FormEvent, useEffect, useMemo, useState } from 'react';
-import { Link, useNavigate, useParams } from 'react-router-dom';
+import { Link, useLocation, useNavigate, useParams } from 'react-router-dom';
 import { useAuth } from '../app/AuthContext';
 import { api } from '../shared/api/client';
 import { useAsync } from '../shared/hooks/useAsync';
@@ -24,6 +24,7 @@ export function ActivityManagePage() {
   const { teamId: teamIdParam } = useParams();
   const teamId = Number(teamIdParam);
   const { user } = useAuth();
+  const { hash } = useLocation();
   const navigate = useNavigate();
   const [selectedMemberId, setSelectedMemberId] = useState<number | null>(null);
   const [scope, setScope] = useState<Scope>('주간');
@@ -49,6 +50,13 @@ export function ActivityManagePage() {
   const team = teams.data?.find((item) => item.team_id === teamId);
   const selectedMember = members.data?.find((member) => member.user_id === selectedMemberId);
   const isLeader = Number(team?.leader_user_id) === user?.id;
+  useEffect(() => {
+    if (!hash || teams.loading || members.loading) return;
+    const frame = window.requestAnimationFrame(() => {
+      document.getElementById(hash.slice(1))?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+    return () => window.cancelAnimationFrame(frame);
+  }, [hash, members.loading, teams.loading]);
   const completion = useMemo(() => {
     const list = todos.data || [];
     return list.length ? Math.round((list.filter((todo) => todo.status === '완료').length / list.length) * 100) : 0;
@@ -151,7 +159,7 @@ export function ActivityManagePage() {
     {(message || error) && <div className={error ? 'form-error' : 'form-success'}>{error || message}</div>}
 
     <div className="activity-manage-grid">
-      <section className="content-card team-goal-manager">
+      <section className="content-card team-goal-manager" id="team-goals">
         <div className="dashboard-section-head"><div><span className="eyebrow">TEAM GOALS</span><h3>팀원 목표</h3></div><strong>{completion}% 완료</strong></div>
         <div className="member-tabs">{members.data?.map((member) => <button className={member.user_id === selectedMemberId ? 'active' : ''} onClick={() => setSelectedMemberId(member.user_id)} key={member.user_id}><span><UserRound /></span><strong>{member.name}</strong><small>{member.part || '역할 미정'}</small></button>)}</div>
         <div className="team-goal-filters"><select value={scope} onChange={(event) => setScope(event.target.value as Scope)}><option>일일</option><option>주간</option><option>월간</option></select><input type="date" value={range.start} onChange={(event) => setRange((current) => ({ ...current, start: event.target.value }))} /><span>~</span><input type="date" value={range.end} onChange={(event) => setRange((current) => ({ ...current, end: event.target.value }))} /></div>
@@ -159,7 +167,7 @@ export function ActivityManagePage() {
         {todos.loading ? <PageState loading /> : <div className="goal-list">{todos.data?.length ? todos.data.map((todo) => <button className={`goal-row ${todo.status}`} onClick={async () => { await api(`/todos/${todo.todo_id}`, { method: 'PUT', body: JSON.stringify({ status: nextStatus(todo.status) }) }); await todos.reload(); }} key={todo.todo_id}><span>{todo.status === '완료' ? <Check /> : todo.status === '진행중' ? <Clock3 /> : <Circle />}</span><div><strong>{todo.title}</strong><small>{todo.scope_start_date.slice(0, 10)} ~ {todo.scope_end_date.slice(0, 10)}</small></div><em>{todo.status}</em></button>) : <div className="goal-empty">선택한 기간에 목표가 없습니다.</div>}</div>}
       </section>
 
-      <section className="content-card activity-settings-panel">
+      <section className="content-card activity-settings-panel" id="activity-settings">
         <div className="dashboard-section-head"><div><span className="eyebrow">SETTINGS</span><h3>활동 설정</h3></div><Settings2 /></div>
         <form onSubmit={saveSettings}>
           <label>활동 프로젝트명<input name="team_name" defaultValue={team.team_name} disabled={!isLeader} /></label>
@@ -172,7 +180,7 @@ export function ActivityManagePage() {
       </section>
     </div>
 
-    {team.participation_mode === 'TEAM' && <section className="content-card team-issue-tracker">
+    {team.participation_mode === 'TEAM' && <section className="content-card team-issue-tracker" id="team-issues">
       <div className="dashboard-section-head"><div><span className="eyebrow">ISSUE TRACKER</span><h3>팀 이슈 트래커</h3></div><strong>{issues.data?.filter((issue) => issue.status !== 'DONE').length || 0}개 진행 중</strong></div>
       <form className="issue-create-form" onSubmit={addIssue}>
         <label>이슈 제목<input name="title" maxLength={180} required placeholder="확인하거나 해결할 일을 적어주세요" /></label>

--- a/web/src/pages/ActivityPage.tsx
+++ b/web/src/pages/ActivityPage.tsx
@@ -6,10 +6,13 @@ import {
   ChevronRight,
   Circle,
   Clock3,
+  Crown,
   Edit3,
   Flame,
+  ListChecks,
   Plus,
   Save,
+  Settings2,
   Sparkles,
   Target,
   Trash2,
@@ -21,8 +24,9 @@ import { FormEvent, useEffect, useMemo, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import { useAuth } from '../app/AuthContext';
 import { api } from '../shared/api/client';
+import { resolveApiMediaUrl } from '../shared/api/media';
 import { useAsync } from '../shared/hooks/useAsync';
-import type { HeatmapDay, TeamNotice, TeamSummary, Todo } from '../shared/types/domain';
+import type { HeatmapDay, TeamMember, TeamNotice, TeamSummary, Todo } from '../shared/types/domain';
 import { PageState } from '../shared/ui/PageState';
 import { PageTitle } from '../shared/ui/PageTitle';
 
@@ -61,6 +65,17 @@ const nextStatus = (status: Todo['status']): Todo['status'] => status === '미�
     ? '완료'
     : '미진행';
 
+function TeamMemberAvatar({ member }: { member: TeamMember }) {
+  const imageUrl = resolveApiMediaUrl(member.profile_picture);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => setFailed(false), [imageUrl]);
+
+  return imageUrl && !failed
+    ? <img src={imageUrl} alt={`${member.name} 프로필`} onError={() => setFailed(true)} />
+    : <span aria-hidden="true">{member.name?.slice(0, 1) || '?'}</span>;
+}
+
 export function ActivityPage() {
   const { user } = useAuth();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -87,6 +102,7 @@ export function ActivityPage() {
     if (selectedId) setSearchParams({ team: String(selectedId) }, { replace: true });
   }, [selectedId, setSearchParams]);
 
+  const selected = active.data?.find((team) => team.team_id === selectedId) || null;
   const goals = useAsync(async () => {
     if (!selectedId) return { 월간: [], 주간: [], 일일: [] } as Record<GoalScope, Todo[]>;
     const load = (goalScope: GoalScope) => api<Todo[]>(`/todos/${selectedId}?scope_type=${encodeURIComponent(goalScope)}&start=${ranges[goalScope].start}&end=${ranges[goalScope].end}`);
@@ -103,8 +119,13 @@ export function ActivityPage() {
       : Promise.resolve([]),
     [selectedId],
   );
+  const members = useAsync(
+    () => selectedId && selected?.participation_mode === 'TEAM'
+      ? api<TeamMember[]>(`/teams/${selectedId}/members`)
+      : Promise.resolve([]),
+    [selectedId, selected?.participation_mode],
+  );
 
-  const selected = active.data?.find((team) => team.team_id === selectedId) || null;
   const categories = useMemo(() => ['전체', ...new Set((active.data || []).map((team) => team.activity_category || (team.source_type === 'ENTERPRISE_CURRICULUM' ? '기업 커리큘럼' : '팀 활동')))], [active.data]);
   const filteredTeams = useMemo(() => (active.data || []).filter((team) => category === '전체' || (team.activity_category || (team.source_type === 'ENTERPRISE_CURRICULUM' ? '기업 커리큘럼' : '팀 활동')) === category), [active.data, category]);
   useEffect(() => {
@@ -241,6 +262,25 @@ export function ActivityPage() {
             <div className="workspace-kpis"><div><span><CheckCircle2 /></span><strong>{progressOf(goals.data?.월간 || [])}%</strong><small>월간 목표</small></div><div><span><Flame /></span><strong>{todayGoals.filter((goal) => goal.status === '완료').length}/{todayGoals.length}</strong><small>오늘 완료</small></div><div><span><Clock3 /></span><strong>{uniqueGoals.filter((goal) => goal.status === '진행중').length}</strong><small>진행 중</small></div></div>
           </div>
         </section>
+
+        {selected?.participation_mode === 'TEAM' && <section className="selected-team-panel" aria-labelledby="selected-team-heading">
+          <div className="dashboard-section-head"><div><span className="eyebrow">TEAM MEMBERS</span><h3 id="selected-team-heading">선택된 활동 팀원</h3></div><strong>{members.loading ? '확인 중' : `${members.data?.length || 0}명`}</strong></div>
+          {members.loading && <div className="selected-team-state">팀원 정보를 불러오고 있습니다.</div>}
+          {!members.loading && members.error && <div className="selected-team-state error"><span>{members.error}</span><button onClick={members.reload}>다시 시도</button></div>}
+          {!members.loading && !members.error && !members.data?.length && <div className="selected-team-state">현재 확인할 수 있는 팀원이 없습니다.</div>}
+          {!members.loading && !members.error && Boolean(members.data?.length) && <div className="selected-team-members">
+            {members.data?.map((member) => <article key={member.user_id}>
+              <div className="selected-team-avatar"><TeamMemberAvatar member={member} /></div>
+              <div><strong>{member.name}{member.user_id === user?.id && <em>나</em>}</strong><small>{member.department || '소속 미등록'}</small><span>{member.part || '역할 설정 전'}</span></div>
+              {member.role === 'LEADER' && <i title="팀장"><Crown /></i>}
+            </article>)}
+          </div>}
+          <nav className="selected-team-actions" aria-label="선택된 활동 관리 기능">
+            <Link to={`/activity/${selectedId}/manage#team-goals`}><Target /><span><strong>팀원 목표</strong><small>팀원별 목표와 진행률</small></span><ChevronRight /></Link>
+            <Link to={`/activity/${selectedId}/manage#activity-settings`}><Settings2 /><span><strong>역할·활동 설정</strong><small>역할과 프로젝트명 관리</small></span><ChevronRight /></Link>
+            <Link to={`/activity/${selectedId}/manage#team-issues`}><ListChecks /><span><strong>팀 이슈</strong><small>담당자와 해결 상태 관리</small></span><ChevronRight /></Link>
+          </nav>
+        </section>}
 
         <section className="week-visual-card">
           <div className="dashboard-section-head"><div><span className="eyebrow">WEEKLY RHYTHM</span><h3>이번 주 실행 흐름</h3></div><span>{ranges.일일.start} ~ {ranges.일일.end}</span></div>

--- a/web/src/shared/types/domain.ts
+++ b/web/src/shared/types/domain.ts
@@ -115,6 +115,15 @@ export type TeamSummary = {
   source_name?: string;
 };
 
+export type TeamMember = {
+  user_id: number;
+  name: string;
+  department?: string;
+  profile_picture?: string;
+  part?: string;
+  role?: 'LEADER' | 'MEMBER';
+};
+
 export type Todo = {
   todo_id: number;
   title: string;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -452,7 +452,26 @@ body { font-size: 16px; line-height: 1.5; }
 }
 .workspace-manage-row a { display: inline-flex; align-items: center; gap: 6px; color: var(--primary); font-weight: 900; white-space: nowrap; }
 .workspace-manage-row svg { width: 17px; }
+.selected-team-panel { margin-top: 14px; padding: 22px; border: 1px solid var(--border); border-radius: 23px; background: #fff; }
+.selected-team-panel .dashboard-section-head > strong { color: var(--primary); font-size: 14px; }
+.selected-team-members { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 9px; margin-top: 16px; }
+.selected-team-members article { position: relative; min-width: 0; display: grid; grid-template-columns: 44px minmax(0, 1fr) 24px; align-items: center; gap: 10px; padding: 13px; border: 1px solid #eceaf1; border-radius: 15px; background: #fbfafd; }
+.selected-team-avatar, .selected-team-avatar img, .selected-team-avatar > span { width: 44px; height: 44px; }
+.selected-team-avatar img, .selected-team-avatar > span { display: grid; place-items: center; border-radius: 13px; object-fit: cover; color: #fff; background: linear-gradient(135deg, var(--primary), var(--primary-dark)); font-size: 16px; font-weight: 900; }
+.selected-team-members article > div:nth-child(2) { min-width: 0; }
+.selected-team-members article strong, .selected-team-members article small, .selected-team-members article span { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.selected-team-members article strong { font-size: 15px; }.selected-team-members article strong em { margin-left: 5px; padding: 2px 5px; border-radius: 5px; color: var(--primary); background: var(--primary-soft); font-size: 11px; font-style: normal; }
+.selected-team-members article small { margin-top: 2px; color: #8d919c; font-size: 12px; }.selected-team-members article span { margin-top: 4px; color: #565b68; font-size: 13px; font-weight: 800; }
+.selected-team-members article > i { width: 24px; height: 24px; display: grid; place-items: center; border-radius: 8px; color: #b54708; background: #fff7e8; }
+.selected-team-members article > i svg { width: 13px; }
+.selected-team-state { display: flex; align-items: center; justify-content: center; gap: 10px; min-height: 82px; margin-top: 14px; border-radius: 14px; color: var(--text-sub); background: #f8f7fb; font-size: 14px; }
+.selected-team-state.error { color: #b42318; background: #fef3f2; }.selected-team-state button { padding: 6px 9px; border: 0; border-radius: 8px; color: #fff; background: #b42318; font-weight: 800; }
+.selected-team-actions { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; margin-top: 12px; }
+.selected-team-actions a { min-width: 0; display: grid; grid-template-columns: 34px minmax(0, 1fr) 16px; align-items: center; gap: 8px; padding: 11px; border: 1px solid #e6e1fb; border-radius: 13px; color: inherit; background: #faf9ff; }
+.selected-team-actions a:hover { border-color: #cfc4ff; background: var(--primary-soft); }.selected-team-actions a > svg:first-child { width: 17px; color: var(--primary); }.selected-team-actions a > svg:last-child { width: 14px; color: #9b9eaa; }
+.selected-team-actions span { min-width: 0; }.selected-team-actions strong, .selected-team-actions small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }.selected-team-actions strong { font-size: 14px; }.selected-team-actions small { margin-top: 2px; color: var(--text-sub); font-size: 12px; }
 .activity-manage-grid { display: grid; grid-template-columns: minmax(0, 1.45fr) minmax(300px, .75fr); gap: 18px; align-items: start; }
+.team-goal-manager, .activity-settings-panel, .team-issue-tracker { scroll-margin-top: 96px; }
 .team-goal-manager, .activity-settings-panel { padding: 24px; }
 .member-tabs { display: flex; gap: 9px; overflow-x: auto; margin-top: 18px; padding-bottom: 7px; }
 .member-tabs button {
@@ -490,12 +509,15 @@ body { font-size: 16px; line-height: 1.5; }
 
 @media (max-width: 900px) {
   .activity-manage-grid { grid-template-columns: 1fr; }
+  .selected-team-actions { grid-template-columns: 1fr; }
 }
 @media (max-width: 720px) {
   .workspace-manage-row { align-items: flex-start; flex-direction: column; }
   .team-goal-filters { grid-template-columns: 1fr 1fr; }
   .team-goal-filters > span { display: none; }
   .team-goal-add { grid-template-columns: 1fr; }
+  .selected-team-panel { padding: 18px 14px; }
+  .selected-team-members { grid-template-columns: 1fr; }
 }
 
 .evaluation-page-grid { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 1fr); gap: 18px; align-items: start; }


### PR DESCRIPTION
## 변경 내용

- 활동 탭에서 선택한 팀의 팀원 이름, 소속, 역할, 팀장 여부, 프로필 사진을 표시합니다.
- 팀원 목표, 역할·활동 설정, 팀 이슈 관리로 바로 이동하는 링크를 제공합니다.
- 관리 화면의 해당 섹션으로 부드럽게 이동하고 로딩·빈 상태·오류 상태를 구분합니다.
- 팀원 API가 같은 팀 사용자에게 필요한 공개 프로필 필드만 반환하도록 보완합니다.

## 수정 파일

| 파일 | 변경 이유 |
| --- | --- |
| `server/server.js` | 팀원 목록에 소속과 프로필 사진 공개 필드를 추가하고 URL을 정규화 |
| `web/src/pages/ActivityPage.tsx` | 선택 활동 팀원 목록과 관련 관리 기능 링크 표시 |
| `web/src/pages/ActivityManagePage.tsx` | 관리 기능 딥링크의 섹션 이동 지원 |
| `web/src/shared/types/domain.ts` | 웹 팀원 응답 타입 정의 |
| `web/src/styles.css` | 팀원 카드, 상태, 관리 링크의 반응형 스타일 추가 |

## 검증

- [x] 관련 테스트를 실행했습니다.
- [x] 변경된 화면 또는 API를 직접 확인했습니다.
- [x] CodeRabbit 리뷰를 확인했습니다. (`develop` 대상 정책으로 자동 리뷰 생략 상태 확인)

- `npx tsc --noEmit`
- `npm --prefix web run lint`
- `npm --prefix web run build`
- `npm --prefix server test` (57개 통과)
- 실제 로컬 DB 팀에서 팀원 3명과 `department`, `profile_picture` 응답 확인
- 비로그인 팀원 API 요청이 401을 반환하는지 확인
- 로컬 diff 자체 검토 및 변경 파일 범위 확인

## 연결 이슈

Closes #82

## 참고 사항

- 이 PR은 선택 활동의 팀원 및 관련 관리 기능 노출만 다룹니다. 도구 그리드와 히트맵 변경은 별도 이슈에서 처리합니다.
