### PR TITLE
style(activity): 활동 히트맵 크기 축소

### DIFF
--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -559,15 +559,15 @@ body { font-size: 16px; line-height: 1.5; }
 .activity-category-tabs button span { min-width: 22px; padding: 2px 6px; border-radius: 999px; color: inherit; background: rgba(111,76,246,.09); font-size: 13px; }
 .activity-category-tabs button.active span { background: rgba(255,255,255,.18); }
 
-.activity-heatmap-card { margin-top: 14px; padding: 22px; border: 1px solid var(--border); border-radius: 23px; background: #fff; }
-.activity-heatmap-weekdays, .activity-heatmap-grid { display: grid; grid-template-columns: repeat(7, minmax(0, 1fr)); gap: 7px; }
-.activity-heatmap-weekdays { margin: 18px 0 7px; color: #8b8f9a; font-size: 13px; font-weight: 800; text-align: center; }
-.activity-heatmap-grid > span { aspect-ratio: 1.18; display: grid; place-items: center; border: 1px solid rgba(72,54,137,.04); border-radius: 9px; background: #f2f1f5; }
+.activity-heatmap-card { margin-top: 14px; padding: 18px; border: 1px solid var(--border); border-radius: 23px; background: #fff; }
+.activity-heatmap-weekdays, .activity-heatmap-grid { width: min(100%, 310px); display: grid; grid-template-columns: repeat(7, minmax(0, 40px)); justify-content: start; gap: 5px; }
+.activity-heatmap-weekdays { margin: 15px 0 5px; color: #8b8f9a; font-size: 12px; font-weight: 800; text-align: center; }
+.activity-heatmap-grid > span { aspect-ratio: 1; display: grid; place-items: center; border: 1px solid rgba(72,54,137,.04); border-radius: 7px; background: #f2f1f5; }
 .activity-heatmap-grid > span em { color: #7d8190; font-size: 12px; font-style: normal; font-weight: 800; }
 .activity-heatmap-grid > span.heat-1 { background: #dfd7ff; }.activity-heatmap-grid > span.heat-2 { background: #b7a6fa; }.activity-heatmap-grid > span.heat-3 { background: #8569ef; }.activity-heatmap-grid > span.heat-4 { background: #4f2bbd; }
 .activity-heatmap-grid > span.heat-2 em, .activity-heatmap-grid > span.heat-3 em, .activity-heatmap-grid > span.heat-4 em { color: #fff; }
-.activity-heatmap-legend { display: flex; align-items: center; justify-content: flex-end; gap: 5px; margin-top: 12px; color: #8b8f9a; font-size: 12px; }
-.activity-heatmap-legend i { width: 13px; height: 13px; border-radius: 4px; background: #f2f1f5; }.activity-heatmap-legend i.heat-1 { background: #dfd7ff; }.activity-heatmap-legend i.heat-2 { background: #b7a6fa; }.activity-heatmap-legend i.heat-3 { background: #8569ef; }.activity-heatmap-legend i.heat-4 { background: #4f2bbd; }
+.activity-heatmap-legend { width: min(100%, 310px); display: flex; align-items: center; justify-content: flex-end; gap: 4px; margin-top: 9px; color: #8b8f9a; font-size: 11px; }
+.activity-heatmap-legend i { width: 11px; height: 11px; border-radius: 3px; background: #f2f1f5; }.activity-heatmap-legend i.heat-1 { background: #dfd7ff; }.activity-heatmap-legend i.heat-2 { background: #b7a6fa; }.activity-heatmap-legend i.heat-3 { background: #8569ef; }.activity-heatmap-legend i.heat-4 { background: #4f2bbd; }
 
 .notice-item-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 12px; }
 .notice-item-head > span { display: flex; gap: 4px; }
@@ -622,7 +622,7 @@ body { font-size: 16px; line-height: 1.5; }
   .issue-create-form { grid-template-columns: 1fr 1fr; }.issue-create-form label.wide { grid-column: 1 / -1; }.issue-create-form > button { grid-column: 1 / -1; }
 }
 @media (max-width: 720px) {
-  .activity-heatmap-card { padding: 18px 14px; }.activity-heatmap-weekdays, .activity-heatmap-grid { gap: 4px; }.activity-heatmap-grid > span { border-radius: 6px; }
+  .activity-heatmap-card { padding: 15px 14px; }.activity-heatmap-weekdays, .activity-heatmap-grid { gap: 4px; }.activity-heatmap-grid > span { border-radius: 6px; }
   .issue-create-form { grid-template-columns: 1fr; }.issue-create-form label.wide, .issue-create-form > button { grid-column: auto; }
   .issue-list article { grid-template-columns: 72px 1fr 72px; }.issue-delete-button { grid-column: 3; }.issue-list article > div { grid-column: 2 / 4; grid-row: 1 / 3; }
 }


### PR DESCRIPTION
## 변경 내용

- 월간 히트맵 본체 최대 너비를 310px로 제한했습니다.
- 날짜 셀을 최대 40px 정사각형으로 줄이고 간격과 카드 여백을 축소했습니다.
- 모바일에서는 가용 너비에 맞춰 7열이 자동으로 더 작아집니다.
- 날짜 숫자, 완료 강도 색상, 범례는 그대로 식별할 수 있게 유지했습니다.

## 수정 파일

| 파일 | 변경 |
| --- | --- |
| `web/src/styles.css` | 히트맵 최대 너비·셀·간격·여백·범례 크기 조정 |

## 검증

- [x] `git diff --check`
- [x] `npx tsc --noEmit`
- [x] `npm --prefix web run lint`
- [x] `npm --prefix web run build`
- [x] `npm test -- --runInBand` (4/4)
- [x] 변경 diff 자체 리뷰
- [x] CodeRabbit 상태 확인 (develop 대상 정책으로 자동 리뷰 생략, 변경 diff 자체 리뷰 완료)

## 연결 이슈

Closes #84
