### PR TITLE
chore(database): 실제 활동 기반 지난 활동 예시 추가

### DIFF
--- a/server/lib/test/pastActivityFixtures.tests.js
+++ b/server/lib/test/pastActivityFixtures.tests.js
@@ -1,0 +1,74 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const {
+  HISTORY_SEED_MARKERS,
+  buildHistoryPeriod,
+  createHistoryFixture,
+  hasVerifiedCommendationPrize,
+  selectHistoryActivities,
+} = require('../../seeds/pastActivityFixtures');
+
+const actualActivities = [
+  {
+    activity_id: 29,
+    title: '제17회 LH 국토기술대전',
+    source_name: '위비티',
+    source_url: 'https://example.com/lh',
+    topic_category: '기획·아이디어',
+    prize_details: '장려상 100만원',
+    application_period_start: '2026-07-27',
+    application_period_end: '2026-08-28',
+    is_hidden: 0,
+  },
+  {
+    activity_id: 33,
+    title: '제24회 임베디드SW경진대회',
+    source_name: '씽굿',
+    source_url: 'https://example.com/sw',
+    topic_category: 'IT·소프트웨어',
+    prize_details: '대상 300만원',
+    application_period_start: '2026-05-06',
+    application_period_end: '2026-09-03',
+    is_hidden: 0,
+  },
+  {
+    activity_id: 99,
+    title: '로컬 데모',
+    source_name: 'local-demo',
+    prize_details: '장려상 100만원',
+    is_hidden: 0,
+  },
+];
+
+test('실제 수집된 수상 공고와 IT 공고를 고정 순서로 선택한다', () => {
+  assert.deepEqual(
+    selectHistoryActivities(actualActivities).map((activity) => activity.activity_id),
+    [29, 33],
+  );
+});
+
+test('장려상 100만 원이 원문에 있을 때만 수상 예시로 인정한다', () => {
+  assert.equal(hasVerifiedCommendationPrize(actualActivities[0]), true);
+  assert.equal(hasVerifiedCommendationPrize(actualActivities[1]), false);
+});
+
+test('지난 활동 종료일은 오늘보다 미래가 되지 않는다', () => {
+  const period = buildHistoryPeriod(actualActivities[1], new Date('2026-08-31T12:00:00'), 1);
+  assert.deepEqual(period, { start: '2026-05-06', end: '2026-08-24' });
+});
+
+test('두 시드 슬롯은 재실행해도 같은 마커와 수상 정책을 사용한다', () => {
+  const first = createHistoryFixture(0, actualActivities[0], new Date('2026-08-31T12:00:00'));
+  const second = createHistoryFixture(1, actualActivities[1], new Date('2026-08-31T12:00:00'));
+
+  assert.equal(first.marker, HISTORY_SEED_MARKERS[0]);
+  assert.equal(second.marker, HISTORY_SEED_MARKERS[1]);
+  assert.deepEqual(first.award, {
+    is_awarded: true,
+    award_title: '장려상',
+    has_prize: true,
+    prize_amount: 1000000,
+    tax_applied: true,
+  });
+  assert.deepEqual(second.award, { is_awarded: false });
+});

--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
     "crawl:competitions": "node crawler/index.js",
     "crawl:competitions:dry": "node crawler/index.js --dry-run --limit 5",
     "seed:current-activity": "node seeds/seedCurrentActivity.js",
+    "seed:past-activity-history": "node seeds/seedPastActivityHistory.js",
     "seed:curricula": "node seeds/seedCurricula.js",
     "admin:provision": "node scripts/provisionAdmin.js",
     "test": "node --test applications/test/*.tests.js crawler/test/*.tests.js portfolio/test/*.tests.js lib/test/*.tests.js"

--- a/server/seeds/pastActivityFixtures.js
+++ b/server/seeds/pastActivityFixtures.js
@@ -1,0 +1,159 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+const HISTORY_SEED_MARKERS = [
+  '[past-activity-seed:v1:slot-1]',
+  '[past-activity-seed:v1:slot-2]',
+];
+
+const REAL_SOURCES = new Set(['위비티', '씽굿']);
+
+const toDateKey = (value) => {
+  const date = value instanceof Date ? value : new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, '0'),
+    String(date.getDate()).padStart(2, '0'),
+  ].join('-');
+};
+
+const addDays = (value, days) => {
+  const date = value instanceof Date ? new Date(value) : new Date(value);
+  date.setDate(date.getDate() + days);
+  return date;
+};
+
+const hasVerifiedCommendationPrize = (activity) => {
+  const prize = String(activity?.prize_details || '').replace(/\s/g, '');
+  return /장려상?/.test(prize) && /(100만원|1,?000,?000원)/.test(prize);
+};
+
+const isRealCollectedActivity = (activity) =>
+  REAL_SOURCES.has(activity?.source_name) && !Number(activity?.is_hidden || 0);
+
+const selectHistoryActivities = (activities = []) => {
+  const realActivities = activities.filter(isRealCollectedActivity);
+  const awardActivity = realActivities.find((activity) =>
+    /LH\s*국토기술대전/i.test(String(activity.title || ''))
+      && hasVerifiedCommendationPrize(activity));
+
+  const technicalActivity = realActivities.find((activity) =>
+    Number(activity.activity_id) !== Number(awardActivity?.activity_id)
+      && (/임베디드\s*SW/i.test(String(activity.title || ''))
+        || /IT|소프트웨어/i.test(String(activity.topic_category || ''))));
+
+  return [awardActivity, technicalActivity].filter(Boolean);
+};
+
+const buildHistoryPeriod = (activity, today = new Date(), slotIndex = 0) => {
+  const todayKey = toDateKey(today);
+  const todayDate = new Date(`${todayKey}T12:00:00`);
+  const preferredEnd = activity?.application_period_end || activity?.operation_period_end;
+  const parsedEnd = preferredEnd ? new Date(preferredEnd) : null;
+  const fallbackEnd = addDays(todayDate, slotIndex === 0 ? -3 : -7);
+  const endDate = parsedEnd && !Number.isNaN(parsedEnd.getTime()) && parsedEnd <= todayDate
+    ? parsedEnd
+    : fallbackEnd;
+  const preferredStart = activity?.application_period_start || activity?.operation_period_start;
+  const parsedStart = preferredStart ? new Date(preferredStart) : null;
+  const startDate = parsedStart && !Number.isNaN(parsedStart.getTime()) && parsedStart <= endDate
+    ? parsedStart
+    : new Date(endDate.getTime() - (42 * DAY_MS));
+
+  return { start: toDateKey(startDate), end: toDateKey(endDate) };
+};
+
+const createHistoryFixture = (slotIndex, activity, today = new Date()) => {
+  const period = buildHistoryPeriod(activity, today, slotIndex);
+  const common = {
+    marker: HISTORY_SEED_MARKERS[slotIndex],
+    activity,
+    period,
+    activityType: String(activity.topic_category || activity.category || '공모전').slice(0, 100),
+    sourceLink: activity.official_url || activity.source_url,
+  };
+
+  if (slotIndex === 0) {
+    return {
+      ...common,
+      meetingType: '혼합',
+      memberParts: new Map([
+        [1, ['LEADER', '서비스 기획·발표']],
+        [2, ['MEMBER', '사용자 리서치·UX']],
+        [3, ['MEMBER', '데이터 분석·기술 검증']],
+      ]),
+      todos: [
+        [1, '월간', '국토·도시 기술 문제 정의와 심사 기준 분석'],
+        [1, '월간', '서비스 콘셉트와 핵심 가치 제안 확정'],
+        [1, '주간', '현장 사용자 인터뷰와 사례 조사 정리'],
+        [1, '주간', '제안서 구조와 기대효과 수치화'],
+        [1, '일일', '최종 제출 규격과 증빙자료 점검'],
+        [1, '일일', 'PT 발표 자료와 질의응답 리허설'],
+        [2, '주간', '현장 사용자 여정과 문제 상황 시각화'],
+        [2, '일일', '제안서 정보 구조와 발표 화면 검수'],
+        [3, '주간', '공공 데이터 근거와 효과 측정 지표 검증'],
+        [3, '일일', '기술 구현 가능성과 운영 비용 산정'],
+      ],
+      portfolio: {
+        role: '팀장 · 서비스 기획 및 발표',
+        summary: '국토·도시 분야의 실제 사용자 문제를 정의하고 공공 데이터와 인터뷰를 근거로 해결안을 설계했습니다. 심사 기준에 맞춰 제안서, 효과 지표, 발표 자료를 통합 관리했습니다.',
+        achievements: [
+          '사용자 인터뷰와 공공 데이터 근거를 결합한 문제 정의 완성',
+          '제안서·발표 자료·질의응답 시나리오를 제출 규격에 맞춰 완성',
+          '공식 장려상 수상 및 상금 100만 원 기록',
+        ],
+        reflection: '아이디어의 참신함만큼 문제의 근거와 효과를 수치로 설명하는 일이 중요했습니다. 다음 활동에서는 초기 인터뷰 단계부터 측정 지표를 함께 설계하겠습니다.',
+      },
+      award: {
+        is_awarded: true,
+        award_title: '장려상',
+        has_prize: true,
+        prize_amount: 1000000,
+        tax_applied: true,
+      },
+    };
+  }
+
+  return {
+    ...common,
+    meetingType: '비대면',
+    memberParts: new Map([
+      [1, ['LEADER', '제품 기획·프론트엔드']],
+      [2, ['MEMBER', '사용자 시나리오·UI']],
+      [3, ['MEMBER', '펌웨어·API 연동']],
+    ]),
+    todos: [
+      [1, '월간', '임베디드SW 요구사항과 시스템 아키텍처 확정'],
+      [1, '월간', '센서 데이터 수집·제어 MVP 완성'],
+      [1, '주간', '사용자 시나리오와 인터페이스 프로토타입 구현'],
+      [1, '주간', '펌웨어·API 연동 및 예외 상황 테스트'],
+      [1, '일일', '데모 시나리오 통합 테스트'],
+      [1, '일일', '기술 문서와 발표 자료 최종 검수'],
+      [2, '주간', '사용자 조작 흐름과 화면 상태 정의'],
+      [2, '일일', '데모 화면 접근성과 오류 메시지 점검'],
+      [3, '주간', '센서 통신 규격과 API 응답 구조 구현'],
+      [3, '일일', '네트워크 단절과 센서 오류 복구 테스트'],
+    ],
+    portfolio: {
+      role: '팀장 · 제품 기획 및 프론트엔드',
+      summary: '임베디드SW 요구사항을 사용자 시나리오로 구체화하고 센서·API·인터페이스를 연결한 MVP를 완성했습니다. 오류 상황을 포함한 데모 시나리오와 기술 문서를 팀 단위로 검수했습니다.',
+      achievements: [
+        '센서 데이터 수집부터 화면 제어까지 이어지는 MVP 흐름 완성',
+        '네트워크 단절·센서 오류를 포함한 통합 테스트 시나리오 정리',
+        '기술 문서와 최종 데모 발표 자료 제출',
+      ],
+      reflection: '하드웨어와 소프트웨어의 경계에서는 정상 흐름보다 오류 복구 기준을 먼저 합의해야 일정 지연을 줄일 수 있었습니다. 이후에는 인터페이스 계약 테스트를 초기 단계부터 운영하겠습니다.',
+    },
+    award: { is_awarded: false },
+  };
+};
+
+module.exports = {
+  HISTORY_SEED_MARKERS,
+  buildHistoryPeriod,
+  createHistoryFixture,
+  hasVerifiedCommendationPrize,
+  isRealCollectedActivity,
+  selectHistoryActivities,
+  toDateKey,
+};

--- a/server/seeds/seedPastActivityHistory.js
+++ b/server/seeds/seedPastActivityHistory.js
@@ -1,0 +1,311 @@
+const path = require('path');
+const mysql = require('mysql2/promise');
+const { ensureAwardsSchema, upsertAward } = require('../awards/service');
+const {
+  archiveTeam,
+  ensurePortfolioSchema,
+  updateMiniPortfolio,
+} = require('../portfolio/service');
+const {
+  createHistoryFixture,
+  selectHistoryActivities,
+} = require('./pastActivityFixtures');
+
+require('dotenv').config({
+  path: process.env.KKIRI_HISTORY_ENV_FILE || path.join(__dirname, '..', '.env'),
+});
+
+const getScopeRange = (period, scope) => {
+  const end = new Date(`${period.end}T12:00:00`);
+  if (scope === '일일') return { start: period.end, end: period.end };
+  const days = scope === '주간' ? 6 : 27;
+  const start = new Date(end);
+  start.setDate(end.getDate() - days);
+  const limitedStart = start < new Date(`${period.start}T12:00:00`)
+    ? period.start
+    : [
+      start.getFullYear(),
+      String(start.getMonth() + 1).padStart(2, '0'),
+      String(start.getDate()).padStart(2, '0'),
+    ].join('-');
+  return { start: limitedStart, end: period.end };
+};
+
+const upsertCompletedTodo = async (connection, teamId, todo, period) => {
+  const [userId, scope, title] = todo;
+  const range = getScopeRange(period, scope);
+  const [rows] = await connection.execute(
+    `SELECT todo_id FROM todos
+     WHERE team_id = ? AND assigned_user_id = ? AND title = ? AND scope_type = ?
+     LIMIT 1`,
+    [teamId, userId, title, scope],
+  );
+  const completedAt = `${range.end} 18:00:00`;
+
+  if (rows.length) {
+    await connection.execute(
+      `UPDATE todos
+       SET status = '완료', scope_start_date = ?, scope_end_date = ?, completed_at = ?
+       WHERE todo_id = ?`,
+      [range.start, range.end, completedAt, rows[0].todo_id],
+    );
+    return rows[0].todo_id;
+  }
+
+  const [result] = await connection.execute(
+    `INSERT INTO todos
+      (team_id, assigned_user_id, title, status, scope_type, scope_start_date, scope_end_date, completed_at)
+     VALUES (?, ?, ?, '완료', ?, ?, ?, ?)`,
+    [teamId, userId, title, scope, range.start, range.end, completedAt],
+  );
+  return result.insertId;
+};
+
+const upsertRecruitment = async (connection, fixture) => {
+  const { activity, marker, period } = fixture;
+  const [rows] = await connection.execute(
+    `SELECT recruitment_id, team_id
+     FROM team_recruitments
+     WHERE memo LIKE ?
+     ORDER BY recruitment_id
+     LIMIT 1`,
+    [`${marker}%`],
+  );
+  const postName = `${activity.title} 완료 활동 기록`.slice(0, 255);
+  const memo = `${marker}\n${activity.source_name}에서 수집한 실제 공고를 기반으로 만든 지난 활동 예시입니다.`;
+  let recruitmentId = rows[0]?.recruitment_id;
+
+  if (!recruitmentId) {
+    const [result] = await connection.execute(
+      `INSERT INTO team_recruitments
+        (owner_user_id, activity_id, post_name, activity_name, activity_type,
+         required_members, activity_start_date, activity_end_date, activity_period,
+         meeting_type, recruitment_scope, memo, status)
+       VALUES (1, ?, ?, ?, ?, 3, ?, ?, ?, ?, 'NATIONWIDE', ?, 'CLOSED')`,
+      [
+        activity.activity_id,
+        postName,
+        activity.title,
+        fixture.activityType,
+        period.start,
+        period.end,
+        `${period.start} ~ ${period.end}`,
+        fixture.meetingType,
+        memo,
+      ],
+    );
+    recruitmentId = result.insertId;
+  } else {
+    await connection.execute(
+      `UPDATE team_recruitments
+       SET owner_user_id = 1, activity_id = ?, post_name = ?, activity_name = ?,
+           activity_type = ?, required_members = 3, activity_start_date = ?,
+           activity_end_date = ?, activity_period = ?, meeting_type = ?,
+           recruitment_scope = 'NATIONWIDE', memo = ?, status = 'CLOSED', deleted_at = NULL
+       WHERE recruitment_id = ?`,
+      [
+        activity.activity_id,
+        postName,
+        activity.title,
+        fixture.activityType,
+        period.start,
+        period.end,
+        `${period.start} ~ ${period.end}`,
+        fixture.meetingType,
+        memo,
+        recruitmentId,
+      ],
+    );
+  }
+
+  return { recruitmentId, teamId: rows[0]?.team_id };
+};
+
+const upsertTeam = async (connection, fixture, recruitmentId, linkedTeamId) => {
+  let teamId = linkedTeamId;
+  if (!teamId) {
+    const [rows] = await connection.execute(
+      'SELECT team_id FROM teams WHERE recruitment_id = ? ORDER BY team_id LIMIT 1',
+      [recruitmentId],
+    );
+    teamId = rows[0]?.team_id;
+  }
+
+  const teamName = `${fixture.activity.title} 팀`.slice(0, 255);
+  if (!teamId) {
+    const [result] = await connection.execute(
+      `INSERT INTO teams
+        (recruitment_id, team_name, leader_user_id, required_members, status, due_date,
+         activity_status, source_type, source_id, participation_mode, visibility)
+       VALUES (?, ?, 1, 3, 'ACTIVE', ?, 'IN_PROGRESS', 'COMPETITION', ?, 'TEAM', 'CLOSED')`,
+      [recruitmentId, teamName, fixture.period.end, fixture.activity.activity_id],
+    );
+    teamId = result.insertId;
+  } else {
+    await connection.execute(
+      `UPDATE teams
+       SET recruitment_id = ?, team_name = ?, leader_user_id = 1, required_members = 3,
+           status = 'ACTIVE', due_date = ?, activity_status = 'IN_PROGRESS',
+           source_type = 'COMPETITION', source_id = ?, participation_mode = 'TEAM', visibility = 'CLOSED'
+       WHERE team_id = ?`,
+      [recruitmentId, teamName, fixture.period.end, fixture.activity.activity_id, teamId],
+    );
+  }
+
+  await connection.execute(
+    'UPDATE team_recruitments SET team_id = ? WHERE recruitment_id = ?',
+    [teamId, recruitmentId],
+  );
+  return teamId;
+};
+
+const seedFixture = async (connection, fixture, users) => {
+  const { recruitmentId, teamId: linkedTeamId } = await upsertRecruitment(connection, fixture);
+  const teamId = await upsertTeam(connection, fixture, recruitmentId, linkedTeamId);
+
+  for (const user of users) {
+    const [role, part] = fixture.memberParts.get(Number(user.id));
+    await connection.execute(
+      `INSERT INTO team_members (team_id, user_id, role, part)
+       VALUES (?, ?, ?, ?)
+       ON DUPLICATE KEY UPDATE role = VALUES(role), part = VALUES(part)`,
+      [teamId, user.id, role, part],
+    );
+  }
+
+  for (const todo of fixture.todos) {
+    await upsertCompletedTodo(connection, teamId, todo, fixture.period);
+  }
+
+  await archiveTeam(connection, teamId, 'SEED_EXAMPLE', { useTransaction: false });
+  const [portfolios] = await connection.execute(
+    'SELECT portfolio_id FROM miniportfolios WHERE user_id = 1 AND team_id = ? LIMIT 1',
+    [teamId],
+  );
+  if (!portfolios.length) throw new Error(`팀 ${teamId}의 미니포트폴리오 생성에 실패했습니다.`);
+
+  const portfolioId = portfolios[0].portfolio_id;
+  await updateMiniPortfolio(connection, 1, portfolioId, {
+    title: fixture.activity.title,
+    activity_type: fixture.activityType,
+    role: fixture.portfolio.role,
+    summary: fixture.portfolio.summary,
+    achievements: fixture.portfolio.achievements,
+    reflection: fixture.portfolio.reflection,
+    image_urls: [],
+    links: fixture.sourceLink
+      ? [{ title: `${fixture.activity.source_name} 공고 원문`, url: fixture.sourceLink }]
+      : [],
+  });
+  await upsertAward(connection, 1, portfolioId, fixture.award);
+
+  return {
+    marker: fixture.marker,
+    activityId: Number(fixture.activity.activity_id),
+    activityTitle: fixture.activity.title,
+    sourceName: fixture.activity.source_name,
+    recruitmentId: Number(recruitmentId),
+    teamId: Number(teamId),
+    portfolioId: Number(portfolioId),
+    awarded: Boolean(fixture.award.is_awarded),
+  };
+};
+
+const run = async () => {
+  const pool = mysql.createPool({
+    host: process.env.DB_HOST || 'localhost',
+    user: process.env.DB_USER || 'root',
+    password: process.env.DB_PASSWORD || '',
+    database: process.env.DB_NAME || 'myappdb',
+    port: Number(process.env.DB_PORT || 3306),
+    connectionLimit: 2,
+    charset: 'utf8mb4',
+  });
+  const connection = await pool.getConnection();
+
+  try {
+    await ensurePortfolioSchema(connection);
+    await ensureAwardsSchema(connection);
+    await connection.beginTransaction();
+
+    const [users] = await connection.execute(
+      'SELECT id, name FROM users WHERE id IN (1, 2, 3) ORDER BY id',
+    );
+    if (users.length !== 3) {
+      throw new Error('지난 활동 예시에 필요한 개발 사용자 1, 2, 3번을 모두 찾을 수 없습니다.');
+    }
+
+    const [activities] = await connection.execute(
+      `SELECT activity_id, title, category, topic_category, source_name, source_url,
+              official_url, prize_details, is_hidden, operation_period_start,
+              operation_period_end, application_period_start, application_period_end
+       FROM activitys
+       WHERE source_name IN ('위비티', '씽굿') AND COALESCE(is_hidden, 0) = 0
+       ORDER BY application_period_end DESC, activity_id DESC
+       LIMIT 300`,
+    );
+    const selectedActivities = selectHistoryActivities(activities);
+    if (selectedActivities.length !== 2) {
+      throw new Error('LH 국토기술대전 수상 공고와 임베디드SW 공고를 실제 수집 데이터에서 모두 찾을 수 없습니다.');
+    }
+
+    const today = new Date();
+    const results = [];
+    for (const [slotIndex, activity] of selectedActivities.entries()) {
+      results.push(await seedFixture(
+        connection,
+        createHistoryFixture(slotIndex, activity, today),
+        users,
+      ));
+    }
+
+    const [[verification]] = await connection.execute(
+      `SELECT
+        COUNT(DISTINCT tr.recruitment_id) AS recruitment_count,
+        COUNT(DISTINCT t.team_id) AS team_count,
+        COUNT(DISTINCT mp.portfolio_id) AS portfolio_count,
+        COUNT(DISTINCT CASE WHEN ua.is_awarded = 1 THEN ua.award_id END) AS award_count,
+        COUNT(DISTINCT CASE WHEN todo.assigned_user_id = 1 AND todo.status = '완료' THEN todo.todo_id END) AS completed_todo_count,
+        COUNT(DISTINCT CASE WHEN a.source_name NOT IN ('위비티', '씽굿') THEN a.activity_id END) AS invalid_source_count
+       FROM team_recruitments tr
+       JOIN teams t ON t.recruitment_id = tr.recruitment_id
+       JOIN activitys a ON a.activity_id = tr.activity_id
+       LEFT JOIN miniportfolios mp ON mp.team_id = t.team_id AND mp.user_id = 1
+       LEFT JOIN user_awards ua ON ua.portfolio_id = mp.portfolio_id AND ua.user_id = 1
+       LEFT JOIN todos todo ON todo.team_id = t.team_id
+       WHERE tr.memo LIKE '[past-activity-seed:v1:slot-%'`,
+    );
+    const verified = {
+      recruitmentCount: Number(verification.recruitment_count),
+      teamCount: Number(verification.team_count),
+      portfolioCount: Number(verification.portfolio_count),
+      awardCount: Number(verification.award_count),
+      completedTodoCount: Number(verification.completed_todo_count),
+      invalidSourceCount: Number(verification.invalid_source_count),
+    };
+    if (
+      verified.recruitmentCount !== 2
+      || verified.teamCount !== 2
+      || verified.portfolioCount !== 2
+      || verified.awardCount < 1
+      || verified.completedTodoCount < 12
+      || verified.invalidSourceCount !== 0
+    ) {
+      throw new Error(`지난 활동 시드 관계 검증에 실패했습니다: ${JSON.stringify(verified)}`);
+    }
+
+    await connection.commit();
+    console.log(JSON.stringify({ seeded: results, verification: verified }, null, 2));
+  } catch (error) {
+    await connection.rollback();
+    throw error;
+  } finally {
+    connection.release();
+    await pool.end();
+  }
+};
+
+run().catch((error) => {
+  console.error('지난 활동·수상 예시 생성 실패:', error.message);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## 변경 내용

- 위비티·씽굿에서 수집한 실제 공고 중 `제17회 LH 국토기술대전`, `제24회 임베디드SW경진대회`를 지난 활동 예시로 연결했습니다.
- 김끼리 개발 계정에 완료 팀 2개, 구체적인 월간·주간·일일 완료 작업 12개, 미니포트폴리오 2개를 생성합니다.
- LH 공고 원문의 장려상 100만 원 내역을 근거로 수상·제세공과금 정보를 기록합니다.
- 고정 시드 마커와 기존 관계 조회, 포트폴리오·수상 고유키 upsert를 사용해 반복 실행 시 중복을 만들지 않습니다.
- 실행 후 실제 수집 출처, 팀·포트폴리오·수상·완료 작업 관계를 SQL로 자체 검증합니다.

## 수정 파일

| 파일 | 내용 |
| --- | --- |
| `server/seeds/pastActivityFixtures.js` | 실제 활동 선택, 기간, 역할, 작업, 포트폴리오·수상 예시 정의 |
| `server/seeds/seedPastActivityHistory.js` | 멱등 DB 시드와 관계 검증 실행기 |
| `server/lib/test/pastActivityFixtures.tests.js` | 실제 출처 선택·기간·고정 마커·수상 정책 단위 테스트 |
| `server/package.json` | `seed:past-activity-history` 명령 추가 |

## 검증

- `node --check server/seeds/pastActivityFixtures.js`
- `node --check server/seeds/seedPastActivityHistory.js`
- `npm --prefix server test` (61/61 통과)
- `npm --prefix server run seed:past-activity-history` 반복 실행
  - 두 실행 모두 recruitment `5, 6`, team `4, 5`, portfolio `1, 4`로 동일
  - 실제 수집 출처 활동 2개, 팀 2개, 포트폴리오 2개, 수상 1개, 완료 작업 12개
  - 잘못된 출처 0개
- `git diff --check`
- CodeRabbit 상태 확인 (develop 대상 정책으로 자동 리뷰 생략, 변경 diff 자체 리뷰 완료)

## 연결 이슈

Closes #89
