### PR TITLE
feat(activity): 활동별 Markdown 문서 작업 공간 추가

### DIFF
--- a/server/activity-documents/router.js
+++ b/server/activity-documents/router.js
@@ -1,0 +1,113 @@
+const express = require('express');
+const {
+  ActivityDocumentError,
+  createActivityDocument,
+  deleteActivityDocument,
+  getActivityDocument,
+  listActivityDocuments,
+  updateActivityDocument,
+} = require('./service');
+
+const parsePositiveId = (value, field) => {
+  const id = Number(value);
+  if (!Number.isSafeInteger(id) || id < 1) {
+    throw new ActivityDocumentError(`${field} 정보가 올바르지 않습니다`, {
+      statusCode: 400,
+      code: 'INVALID_ACTIVITY_DOCUMENT_ID',
+      details: { field },
+    });
+  }
+  return id;
+};
+
+const parseListLimit = (value) => {
+  const limit = Number(value);
+  return Number.isSafeInteger(limit) ? Math.min(200, Math.max(1, limit)) : 100;
+};
+
+const createActivityDocumentsRouter = ({
+  database,
+  getRequestUserId,
+  getSchemaReady = () => Promise.resolve(),
+  logError = console.error,
+}) => {
+  const router = express.Router({ mergeParams: true });
+
+  router.use((req, res, next) => {
+    res.setHeader('Cache-Control', 'private, no-store');
+    next();
+  });
+
+  const handle = (operation) => async (req, res) => {
+    try {
+      await getSchemaReady();
+      const userId = Number(getRequestUserId(req));
+      if (!Number.isSafeInteger(userId) || userId < 1) {
+        return res.status(401).json({ message: '로그인이 필요합니다' });
+      }
+      return await operation(req, res, userId);
+    } catch (error) {
+      if (error instanceof ActivityDocumentError) {
+        return res.status(error.statusCode).json({
+          message: error.message,
+          code: error.code,
+          ...(error.details || {}),
+        });
+      }
+      logError('활동 문서 처리 오류:', error);
+      return res.status(500).json({ message: '활동 문서를 처리하지 못했습니다' });
+    }
+  };
+
+  router.get('/', handle(async (req, res, userId) => {
+    const teamId = parsePositiveId(req.params.teamId, '활동');
+    const documents = await listActivityDocuments(database, teamId, userId, parseListLimit(req.query.limit));
+    return res.json(documents);
+  }));
+
+  router.post('/', handle(async (req, res, userId) => {
+    const teamId = parsePositiveId(req.params.teamId, '활동');
+    const document = await createActivityDocument(database, teamId, userId, req.body);
+    return res.status(201).json(document);
+  }));
+
+  router.get('/:documentId', handle(async (req, res, userId) => {
+    const teamId = parsePositiveId(req.params.teamId, '활동');
+    const documentId = parsePositiveId(req.params.documentId, '문서');
+    const document = await getActivityDocument(database, teamId, userId, documentId);
+    return res.json(document);
+  }));
+
+  router.put('/:documentId', handle(async (req, res, userId) => {
+    const teamId = parsePositiveId(req.params.teamId, '활동');
+    const documentId = parsePositiveId(req.params.documentId, '문서');
+    const document = await updateActivityDocument(database, teamId, userId, documentId, req.body);
+    return res.json(document);
+  }));
+
+  router.delete('/:documentId', handle(async (req, res, userId) => {
+    const teamId = parsePositiveId(req.params.teamId, '활동');
+    const documentId = parsePositiveId(req.params.documentId, '문서');
+    const document = await deleteActivityDocument(
+      database,
+      teamId,
+      userId,
+      documentId,
+      req.body?.version,
+    );
+    return res.json({
+      success: true,
+      document_id: document.document_id,
+      version: document.version,
+      deleted_at: document.deleted_at,
+    });
+  }));
+
+  return router;
+};
+
+module.exports = {
+  createActivityDocumentsRouter,
+  parseListLimit,
+  parsePositiveId,
+};

--- a/server/activity-documents/service.js
+++ b/server/activity-documents/service.js
@@ -1,0 +1,272 @@
+const DOCUMENT_LIMITS = Object.freeze({
+  title: 160,
+  contentMarkdown: 100_000,
+});
+
+class ActivityDocumentError extends Error {
+  constructor(message, { statusCode = 400, code = 'ACTIVITY_DOCUMENT_ERROR', details } = {}) {
+    super(message);
+    this.name = 'ActivityDocumentError';
+    this.statusCode = statusCode;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+const countCharacters = (value) => Array.from(value).length;
+
+const validationError = (message, field) => new ActivityDocumentError(message, {
+  statusCode: 400,
+  code: 'INVALID_ACTIVITY_DOCUMENT',
+  details: { field },
+});
+
+const sanitizeDocumentInput = (input = {}) => {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw validationError('활동 문서 요청 본문이 올바르지 않습니다', 'body');
+  }
+  if (typeof input.title !== 'string') {
+    throw validationError('문서 제목은 문자열이어야 합니다', 'title');
+  }
+
+  const title = input.title.trim();
+  if (!title) {
+    throw validationError('문서 제목을 입력해주세요', 'title');
+  }
+  if (countCharacters(title) > DOCUMENT_LIMITS.title) {
+    throw validationError(`문서 제목은 ${DOCUMENT_LIMITS.title}자 이하여야 합니다`, 'title');
+  }
+
+  if (typeof input.content_markdown !== 'string') {
+    throw validationError('Markdown 본문은 문자열이어야 합니다', 'content_markdown');
+  }
+
+  const contentMarkdown = input.content_markdown.replace(/\r\n?/g, '\n');
+  if (contentMarkdown.includes('\u0000')) {
+    throw validationError('Markdown 본문에 허용되지 않는 문자가 있습니다', 'content_markdown');
+  }
+  if (countCharacters(contentMarkdown) > DOCUMENT_LIMITS.contentMarkdown) {
+    throw validationError(
+      `Markdown 본문은 ${DOCUMENT_LIMITS.contentMarkdown.toLocaleString('ko-KR')}자 이하여야 합니다`,
+      'content_markdown',
+    );
+  }
+
+  return { title, contentMarkdown };
+};
+
+const parseExpectedVersion = (value) => {
+  const version = Number(value);
+  if (!Number.isSafeInteger(version) || version < 1) {
+    throw validationError('올바른 문서 version이 필요합니다', 'version');
+  }
+  return version;
+};
+
+const ensureActivityDocumentsSchema = async (database) => {
+  await database.query(`CREATE TABLE IF NOT EXISTS activity_documents (
+    document_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    team_id INT NOT NULL,
+    author_id INT NOT NULL,
+    last_editor_id INT NOT NULL,
+    title VARCHAR(160) NOT NULL,
+    content_markdown MEDIUMTEXT NOT NULL,
+    version INT UNSIGNED NOT NULL DEFAULT 1,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    deleted_at DATETIME NULL,
+    INDEX idx_activity_documents_team_deleted_updated (team_id, deleted_at, updated_at, document_id),
+    INDEX idx_activity_documents_author (author_id),
+    INDEX idx_activity_documents_last_editor (last_editor_id)
+  ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4`);
+};
+
+const assertTeamMember = async (database, teamId, userId, { forUpdate = false } = {}) => {
+  const [rows] = await database.query(
+    `SELECT tm.user_id
+     FROM team_members tm
+     JOIN users u ON u.id = tm.user_id
+     WHERE tm.team_id = ? AND tm.user_id = ?
+     LIMIT 1${forUpdate ? ' FOR UPDATE' : ''}`,
+    [teamId, userId],
+  );
+
+  if (!rows.length) {
+    throw new ActivityDocumentError('팀원만 활동 문서에 접근할 수 있습니다', {
+      statusCode: 403,
+      code: 'ACTIVITY_DOCUMENT_TEAM_MEMBERS_ONLY',
+    });
+  }
+};
+
+const DOCUMENT_METADATA_SELECT = `
+  SELECT d.document_id, d.team_id, d.author_id, d.last_editor_id,
+    d.title, d.version, d.created_at, d.updated_at, d.deleted_at,
+    COALESCE(creator.name, '알 수 없음') AS creator_name,
+    COALESCE(editor.name, '알 수 없음') AS editor_name
+  FROM activity_documents d
+  LEFT JOIN users creator ON creator.id = d.author_id
+  LEFT JOIN users editor ON editor.id = d.last_editor_id
+`;
+
+const DOCUMENT_SELECT = DOCUMENT_METADATA_SELECT.replace(
+  'd.title, d.version',
+  'd.title, d.content_markdown, d.version',
+);
+
+const findDocument = async (database, teamId, documentId, { includeDeleted = false } = {}) => {
+  const [rows] = await database.query(
+    `${DOCUMENT_SELECT}
+     WHERE d.document_id = ? AND d.team_id = ?${includeDeleted ? '' : ' AND d.deleted_at IS NULL'}
+     LIMIT 1`,
+    [documentId, teamId],
+  );
+  return rows[0] || null;
+};
+
+const listActivityDocuments = async (database, teamId, userId, limit = 100) => {
+  await assertTeamMember(database, teamId, userId);
+  const [rows] = await database.query(
+    `${DOCUMENT_METADATA_SELECT}
+     WHERE d.team_id = ? AND d.deleted_at IS NULL
+     ORDER BY d.updated_at DESC, d.document_id DESC
+     LIMIT ?`,
+    [teamId, limit],
+  );
+  return rows;
+};
+
+const getActivityDocument = async (database, teamId, userId, documentId) => {
+  await assertTeamMember(database, teamId, userId);
+  const document = await findDocument(database, teamId, documentId);
+  if (!document) {
+    throw new ActivityDocumentError('활동 문서를 찾을 수 없습니다', {
+      statusCode: 404,
+      code: 'ACTIVITY_DOCUMENT_NOT_FOUND',
+    });
+  }
+  return document;
+};
+
+const withTransaction = async (database, operation) => {
+  const connection = typeof database.getConnection === 'function'
+    ? await database.getConnection()
+    : database;
+  const shouldRelease = connection !== database && typeof connection.release === 'function';
+  let transactionStarted = false;
+
+  try {
+    await connection.beginTransaction();
+    transactionStarted = true;
+    const result = await operation(connection);
+    await connection.commit();
+    return result;
+  } catch (error) {
+    if (transactionStarted) {
+      try {
+        await connection.rollback();
+      } catch (rollbackError) {
+        error.rollbackError = rollbackError;
+      }
+    }
+    throw error;
+  } finally {
+    if (shouldRelease) connection.release();
+  }
+};
+
+const createActivityDocument = async (database, teamId, userId, input) => {
+  const document = sanitizeDocumentInput(input);
+  return withTransaction(database, async (connection) => {
+    await assertTeamMember(connection, teamId, userId, { forUpdate: true });
+    const [result] = await connection.query(
+      `INSERT INTO activity_documents
+        (team_id, author_id, last_editor_id, title, content_markdown, version)
+       VALUES (?, ?, ?, ?, ?, 1)`,
+      [teamId, userId, userId, document.title, document.contentMarkdown],
+    );
+    return findDocument(connection, teamId, result.insertId);
+  });
+};
+
+const getCurrentVersion = async (database, teamId, documentId) => {
+  const [rows] = await database.query(
+    `SELECT version, deleted_at
+     FROM activity_documents
+     WHERE document_id = ? AND team_id = ?
+     LIMIT 1`,
+    [documentId, teamId],
+  );
+  return rows[0] || null;
+};
+
+const throwMutationMiss = async (database, teamId, documentId) => {
+  const current = await getCurrentVersion(database, teamId, documentId);
+  if (!current || current.deleted_at) {
+    throw new ActivityDocumentError('활동 문서를 찾을 수 없습니다', {
+      statusCode: 404,
+      code: 'ACTIVITY_DOCUMENT_NOT_FOUND',
+    });
+  }
+
+  throw new ActivityDocumentError('다른 팀원이 먼저 문서를 변경했습니다. 최신 내용을 불러온 뒤 다시 시도해주세요', {
+    statusCode: 409,
+    code: 'DOCUMENT_VERSION_CONFLICT',
+    details: { current_version: Number(current.version) },
+  });
+};
+
+const updateActivityDocument = async (database, teamId, userId, documentId, input) => {
+  const document = sanitizeDocumentInput(input);
+  const version = parseExpectedVersion(input.version);
+
+  return withTransaction(database, async (connection) => {
+    await assertTeamMember(connection, teamId, userId, { forUpdate: true });
+    const [result] = await connection.query(
+      `UPDATE activity_documents
+       SET title = ?, content_markdown = ?, last_editor_id = ?,
+         version = version + 1, updated_at = CURRENT_TIMESTAMP
+       WHERE document_id = ? AND team_id = ? AND version = ? AND deleted_at IS NULL`,
+      [document.title, document.contentMarkdown, userId, documentId, teamId, version],
+    );
+
+    if (!result.affectedRows) {
+      await throwMutationMiss(connection, teamId, documentId);
+    }
+    return findDocument(connection, teamId, documentId);
+  });
+};
+
+const deleteActivityDocument = async (database, teamId, userId, documentId, expectedVersion) => {
+  const version = parseExpectedVersion(expectedVersion);
+
+  return withTransaction(database, async (connection) => {
+    await assertTeamMember(connection, teamId, userId, { forUpdate: true });
+    const [result] = await connection.query(
+      `UPDATE activity_documents
+       SET deleted_at = CURRENT_TIMESTAMP, last_editor_id = ?,
+         version = version + 1, updated_at = CURRENT_TIMESTAMP
+       WHERE document_id = ? AND team_id = ? AND version = ? AND deleted_at IS NULL`,
+      [userId, documentId, teamId, version],
+    );
+
+    if (!result.affectedRows) {
+      await throwMutationMiss(connection, teamId, documentId);
+    }
+    return findDocument(connection, teamId, documentId, { includeDeleted: true });
+  });
+};
+
+module.exports = {
+  ActivityDocumentError,
+  DOCUMENT_LIMITS,
+  assertTeamMember,
+  createActivityDocument,
+  deleteActivityDocument,
+  ensureActivityDocumentsSchema,
+  getActivityDocument,
+  listActivityDocuments,
+  parseExpectedVersion,
+  sanitizeDocumentInput,
+  updateActivityDocument,
+};

--- a/server/lib/test/activityDocuments.tests.js
+++ b/server/lib/test/activityDocuments.tests.js
@@ -1,0 +1,314 @@
+const assert = require('node:assert/strict');
+const { once } = require('node:events');
+const test = require('node:test');
+const express = require('express');
+const {
+  ActivityDocumentError,
+  DOCUMENT_LIMITS,
+  createActivityDocument,
+  deleteActivityDocument,
+  ensureActivityDocumentsSchema,
+  listActivityDocuments,
+  parseExpectedVersion,
+  sanitizeDocumentInput,
+  updateActivityDocument,
+} = require('../../activity-documents/service');
+const {
+  createActivityDocumentsRouter,
+  parseListLimit,
+  parsePositiveId,
+} = require('../../activity-documents/router');
+
+const createScriptedConnection = (responses = []) => {
+  const calls = [];
+  const state = {
+    began: 0,
+    committed: 0,
+    rolledBack: 0,
+    released: 0,
+  };
+  return {
+    calls,
+    state,
+    async query(sql, params = []) {
+      calls.push({ sql, params });
+      assert.ok(responses.length, `예상하지 못한 쿼리: ${sql}`);
+      const response = responses.shift();
+      return typeof response === 'function' ? response(sql, params) : response;
+    },
+    async beginTransaction() { state.began += 1; },
+    async commit() { state.committed += 1; },
+    async rollback() { state.rolledBack += 1; },
+    release() { state.released += 1; },
+  };
+};
+
+const createPool = (connection) => ({
+  async getConnection() {
+    return connection;
+  },
+});
+
+test('Markdown 문서 입력은 제목을 정리하고 본문의 줄바꿈과 표 문법을 보존한다', () => {
+  const document = sanitizeDocumentInput({
+    title: '  주간 회의록  ',
+    content_markdown: '## 결정 사항\r\n\r\n| 담당 | 작업 |\r\n| --- | --- |\r\n| 민지 | API |',
+  });
+
+  assert.equal(document.title, '주간 회의록');
+  assert.equal(document.contentMarkdown, '## 결정 사항\n\n| 담당 | 작업 |\n| --- | --- |\n| 민지 | API |');
+});
+
+test('빈 Markdown 초안은 허용하지만 제목과 본문의 타입·길이는 엄격히 검증한다', () => {
+  assert.equal(sanitizeDocumentInput({ title: '초안', content_markdown: '' }).contentMarkdown, '');
+  assert.throws(
+    () => sanitizeDocumentInput(null),
+    (error) => error.statusCode === 400 && error.details.field === 'body',
+  );
+  assert.throws(
+    () => sanitizeDocumentInput([]),
+    (error) => error.statusCode === 400 && error.details.field === 'body',
+  );
+  assert.throws(
+    () => sanitizeDocumentInput({ title: ' ', content_markdown: '' }),
+    (error) => error instanceof ActivityDocumentError && error.details.field === 'title',
+  );
+  assert.throws(
+    () => sanitizeDocumentInput({ title: '문서', content_markdown: null }),
+    (error) => error instanceof ActivityDocumentError && error.details.field === 'content_markdown',
+  );
+  assert.throws(
+    () => sanitizeDocumentInput({
+      title: '문서',
+      content_markdown: '가'.repeat(DOCUMENT_LIMITS.contentMarkdown + 1),
+    }),
+    (error) => error.statusCode === 400 && error.details.field === 'content_markdown',
+  );
+});
+
+test('version과 경로 ID는 안전한 양의 정수만 허용한다', () => {
+  assert.equal(parseExpectedVersion('3'), 3);
+  assert.equal(parsePositiveId('42', '문서'), 42);
+  for (const invalid of [undefined, 0, -1, 1.5, 'abc']) {
+    assert.throws(() => parseExpectedVersion(invalid), ActivityDocumentError);
+    assert.throws(() => parsePositiveId(invalid, '문서'), ActivityDocumentError);
+  }
+  assert.equal(parseListLimit(undefined), 100);
+  assert.equal(parseListLimit('25'), 25);
+  assert.equal(parseListLimit('999'), 200);
+  assert.equal(parseListLimit('-3'), 1);
+  assert.equal(parseListLimit('3.5'), 100);
+});
+
+test('기존 DB에서도 Markdown, soft-delete, version 컬럼을 포함한 문서 테이블을 준비한다', async () => {
+  const statements = [];
+  const database = {
+    async query(sql) {
+      statements.push(sql);
+      return [[], []];
+    },
+  };
+
+  await ensureActivityDocumentsSchema(database);
+
+  assert.equal(statements.length, 1);
+  assert.match(statements[0], /CREATE TABLE IF NOT EXISTS activity_documents/);
+  assert.match(statements[0], /content_markdown MEDIUMTEXT NOT NULL/);
+  assert.match(statements[0], /version INT UNSIGNED NOT NULL DEFAULT 1/);
+  assert.match(statements[0], /deleted_at DATETIME NULL/);
+});
+
+test('문서 목록은 팀원 확인 후 삭제되지 않은 팀 문서만 파라미터 쿼리로 조회한다', async () => {
+  const documents = [{ document_id: 9, team_id: 4, title: '회의록', version: 2 }];
+  const database = createScriptedConnection([
+    [[{ user_id: 7 }], []],
+    [documents, []],
+  ]);
+
+  assert.deepEqual(await listActivityDocuments(database, 4, 7), documents);
+  assert.deepEqual(database.calls[0].params, [4, 7]);
+  assert.match(database.calls[0].sql, /JOIN users u ON u\.id = tm\.user_id/);
+  assert.deepEqual(database.calls[1].params, [4, 100]);
+  assert.match(database.calls[1].sql, /d\.deleted_at IS NULL/);
+  assert.match(database.calls[1].sql, /LIMIT \?/);
+  assert.doesNotMatch(database.calls[1].sql, /d\.content_markdown/);
+  assert.match(database.calls[1].sql, /creator_name/);
+  assert.match(database.calls[1].sql, /editor_name/);
+});
+
+test('팀원이 아니면 문서 본문을 조회하지 않는다', async () => {
+  const database = createScriptedConnection([
+    [[], []],
+  ]);
+
+  await assert.rejects(
+    () => listActivityDocuments(database, 4, 99),
+    (error) => error.statusCode === 403 && error.code === 'ACTIVITY_DOCUMENT_TEAM_MEMBERS_ONLY',
+  );
+  assert.equal(database.calls.length, 1);
+});
+
+test('문서 생성은 팀원 잠금·INSERT·조회 전체를 한 트랜잭션에서 수행한다', async () => {
+  const saved = {
+    document_id: 15,
+    team_id: 4,
+    author_id: 7,
+    last_editor_id: 7,
+    creator_name: '김팀원',
+    editor_name: '김팀원',
+    title: '킥오프',
+    content_markdown: '# 안건',
+    version: 1,
+  };
+  const connection = createScriptedConnection([
+    [[{ user_id: 7 }], []],
+    [{ insertId: 15, affectedRows: 1 }, []],
+    [[saved], []],
+  ]);
+
+  const result = await createActivityDocument(
+    createPool(connection),
+    4,
+    7,
+    { title: ' 킥오프 ', content_markdown: '# 안건' },
+  );
+
+  assert.deepEqual(result, saved);
+  assert.match(connection.calls[0].sql, /FOR UPDATE/);
+  assert.deepEqual(connection.calls[1].params, [4, 7, 7, '킥오프', '# 안건']);
+  assert.deepEqual(connection.state, { began: 1, committed: 1, rolledBack: 0, released: 1 });
+});
+
+test('트랜잭션 시작 자체가 실패해도 풀 연결을 반드시 반환한다', async () => {
+  const connection = createScriptedConnection([]);
+  connection.beginTransaction = async () => {
+    connection.state.began += 1;
+    throw new Error('begin failed');
+  };
+
+  await assert.rejects(
+    () => createActivityDocument(
+      createPool(connection),
+      4,
+      7,
+      { title: '실패 테스트', content_markdown: '' },
+    ),
+    /begin failed/,
+  );
+
+  assert.deepEqual(connection.state, { began: 1, committed: 0, rolledBack: 0, released: 1 });
+  assert.equal(connection.calls.length, 0);
+});
+
+test('오래된 version으로 수정하면 롤백하고 최신 version을 포함한 409를 반환할 수 있다', async () => {
+  const connection = createScriptedConnection([
+    [[{ user_id: 7 }], []],
+    [{ affectedRows: 0 }, []],
+    [[{ version: 5, deleted_at: null }], []],
+  ]);
+
+  await assert.rejects(
+    () => updateActivityDocument(
+      createPool(connection),
+      4,
+      7,
+      15,
+      { title: '변경', content_markdown: '본문', version: 4 },
+    ),
+    (error) => error.statusCode === 409
+      && error.code === 'DOCUMENT_VERSION_CONFLICT'
+      && error.details.current_version === 5,
+  );
+
+  assert.deepEqual(connection.calls[1].params, ['변경', '본문', 7, 15, 4, 4]);
+  assert.deepEqual(connection.state, { began: 1, committed: 0, rolledBack: 1, released: 1 });
+});
+
+test('문서 삭제는 행을 제거하지 않고 version을 올리며 deleted_at을 기록한다', async () => {
+  const deleted = {
+    document_id: 15,
+    team_id: 4,
+    title: '완료 문서',
+    version: 3,
+    deleted_at: '2026-09-05T10:00:00.000Z',
+  };
+  const connection = createScriptedConnection([
+    [[{ user_id: 7 }], []],
+    [{ affectedRows: 1 }, []],
+    [[deleted], []],
+  ]);
+
+  const result = await deleteActivityDocument(createPool(connection), 4, 7, 15, 2);
+
+  assert.deepEqual(result, deleted);
+  assert.match(connection.calls[1].sql, /SET deleted_at = CURRENT_TIMESTAMP/);
+  assert.match(connection.calls[1].sql, /version = version \+ 1/);
+  assert.deepEqual(connection.calls[1].params, [7, 15, 4, 2]);
+  assert.deepEqual(connection.state, { began: 1, committed: 1, rolledBack: 0, released: 1 });
+});
+
+test('문서 API는 스키마 준비를 기다리고 인증 정보와 no-store 정책을 적용한다', async (context) => {
+  let schemaReadyCount = 0;
+  const app = express();
+  app.use(express.json());
+  app.use('/teams/:teamId/documents', createActivityDocumentsRouter({
+    database: {
+      async query() {
+        throw new Error('잘못된 ID 요청은 DB에 도달하면 안 됩니다');
+      },
+    },
+    getRequestUserId: (req) => req.get('x-test-user') === '7' ? 7 : null,
+    getSchemaReady: async () => { schemaReadyCount += 1; },
+    logError: () => undefined,
+  }));
+  const server = app.listen(0, '127.0.0.1');
+  context.after(() => server.close());
+  await once(server, 'listening');
+
+  const { port } = server.address();
+  const unauthorizedResponse = await fetch(`http://127.0.0.1:${port}/teams/4/documents`);
+  assert.equal(unauthorizedResponse.status, 401);
+  assert.equal(unauthorizedResponse.headers.get('cache-control'), 'private, no-store');
+
+  const response = await fetch(`http://127.0.0.1:${port}/teams/not-a-number/documents`, {
+    headers: { 'x-test-user': '7' },
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 400);
+  assert.equal(response.headers.get('cache-control'), 'private, no-store');
+  assert.equal(body.code, 'INVALID_ACTIVITY_DOCUMENT_ID');
+  assert.equal(schemaReadyCount, 2);
+});
+
+test('문서 API는 optimistic concurrency 충돌을 안정적인 409 응답으로 변환한다', async (context) => {
+  const connection = createScriptedConnection([
+    [[{ user_id: 7 }], []],
+    [{ affectedRows: 0 }, []],
+    [[{ version: 5, deleted_at: null }], []],
+  ]);
+  const app = express();
+  app.use(express.json());
+  app.use('/teams/:teamId/documents', createActivityDocumentsRouter({
+    database: createPool(connection),
+    getRequestUserId: () => 7,
+    logError: () => undefined,
+  }));
+  const server = app.listen(0, '127.0.0.1');
+  context.after(() => server.close());
+  await once(server, 'listening');
+
+  const { port } = server.address();
+  const response = await fetch(`http://127.0.0.1:${port}/teams/4/documents/15`, {
+    method: 'PUT',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ title: '동시 편집', content_markdown: '최신 초안', version: 4 }),
+  });
+  const body = await response.json();
+
+  assert.equal(response.status, 409);
+  assert.equal(response.headers.get('cache-control'), 'private, no-store');
+  assert.equal(body.code, 'DOCUMENT_VERSION_CONFLICT');
+  assert.equal(body.current_version, 5);
+  assert.equal(connection.state.rolledBack, 1);
+});

--- a/server/lib/test/activityDocuments.tests.js
+++ b/server/lib/test/activityDocuments.tests.js
@@ -249,6 +249,10 @@ test('문서 삭제는 행을 제거하지 않고 version을 올리며 deleted_a
 
 test('문서 API는 스키마 준비를 기다리고 인증 정보와 no-store 정책을 적용한다', async (context) => {
   let schemaReadyCount = 0;
+  let resolveSchemaReady;
+  let signalSchemaWaitStarted;
+  const schemaReady = new Promise((resolve) => { resolveSchemaReady = resolve; });
+  const schemaWaitStarted = new Promise((resolve) => { signalSchemaWaitStarted = resolve; });
   const app = express();
   app.use(express.json());
   app.use('/teams/:teamId/documents', createActivityDocumentsRouter({
@@ -258,7 +262,11 @@ test('문서 API는 스키마 준비를 기다리고 인증 정보와 no-store �
       },
     },
     getRequestUserId: (req) => req.get('x-test-user') === '7' ? 7 : null,
-    getSchemaReady: async () => { schemaReadyCount += 1; },
+    getSchemaReady: () => {
+      schemaReadyCount += 1;
+      signalSchemaWaitStarted();
+      return schemaReady;
+    },
     logError: () => undefined,
   }));
   const server = app.listen(0, '127.0.0.1');
@@ -266,18 +274,29 @@ test('문서 API는 스키마 준비를 기다리고 인증 정보와 no-store �
   await once(server, 'listening');
 
   const { port } = server.address();
-  const unauthorizedResponse = await fetch(`http://127.0.0.1:${port}/teams/4/documents`);
-  assert.equal(unauthorizedResponse.status, 401);
-  assert.equal(unauthorizedResponse.headers.get('cache-control'), 'private, no-store');
-
-  const response = await fetch(`http://127.0.0.1:${port}/teams/not-a-number/documents`, {
+  let responseCompleted = false;
+  const responsePromise = fetch(`http://127.0.0.1:${port}/teams/not-a-number/documents`, {
     headers: { 'x-test-user': '7' },
   });
+  responsePromise.then(
+    () => { responseCompleted = true; },
+    () => { responseCompleted = true; },
+  );
+  await schemaWaitStarted;
+  await new Promise((resolve) => setTimeout(resolve, 20));
+  assert.equal(responseCompleted, false);
+
+  resolveSchemaReady();
+  const response = await responsePromise;
   const body = await response.json();
 
   assert.equal(response.status, 400);
   assert.equal(response.headers.get('cache-control'), 'private, no-store');
   assert.equal(body.code, 'INVALID_ACTIVITY_DOCUMENT_ID');
+
+  const unauthorizedResponse = await fetch(`http://127.0.0.1:${port}/teams/4/documents`);
+  assert.equal(unauthorizedResponse.status, 401);
+  assert.equal(unauthorizedResponse.headers.get('cache-control'), 'private, no-store');
   assert.equal(schemaReadyCount, 2);
 });
 

--- a/server/schema/base.sql
+++ b/server/schema/base.sql
@@ -191,6 +191,22 @@ CREATE TABLE IF NOT EXISTS team_notices (
   INDEX idx_team_notices_team_created (team_id, created_at)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 
+CREATE TABLE IF NOT EXISTS activity_documents (
+  document_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  team_id INT NOT NULL,
+  author_id INT NOT NULL,
+  last_editor_id INT NOT NULL,
+  title VARCHAR(160) NOT NULL,
+  content_markdown MEDIUMTEXT NOT NULL,
+  version INT UNSIGNED NOT NULL DEFAULT 1,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  deleted_at DATETIME NULL,
+  INDEX idx_activity_documents_team_deleted_updated (team_id, deleted_at, updated_at, document_id),
+  INDEX idx_activity_documents_author (author_id),
+  INDEX idx_activity_documents_last_editor (last_editor_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
 CREATE TABLE IF NOT EXISTS notice_comments (
   comment_id INT NOT NULL AUTO_INCREMENT PRIMARY KEY,
   notice_id INT NOT NULL,

--- a/server/scripts/verifyDatabase.js
+++ b/server/scripts/verifyDatabase.js
@@ -74,6 +74,16 @@ const run = async () => {
     );
     const tableNames = new Set(tables.map((row) => row.TABLE_NAME || row.table_name));
     const missingTables = requiredTables.filter((table) => !tableNames.has(table));
+    const orphanDocumentsSelect = tableNames.has('activity_documents')
+      ? `(SELECT COUNT(*)
+         FROM activity_documents activity_document
+         LEFT JOIN teams document_team ON document_team.team_id = activity_document.team_id
+         LEFT JOIN users document_creator ON document_creator.id = activity_document.author_id
+         LEFT JOIN users document_editor ON document_editor.id = activity_document.last_editor_id
+         WHERE document_team.team_id IS NULL
+           OR document_creator.id IS NULL
+           OR document_editor.id IS NULL) AS orphan_documents`
+      : '0 AS orphan_documents';
 
     const [[activityStats]] = await connection.query(`
       SELECT
@@ -109,14 +119,7 @@ const run = async () => {
         (SELECT COUNT(*) FROM team_members member LEFT JOIN teams team ON team.team_id = member.team_id WHERE team.team_id IS NULL) AS orphan_memberships,
         (SELECT COUNT(*) FROM todos todo LEFT JOIN teams team ON team.team_id = todo.team_id WHERE team.team_id IS NULL) AS orphan_todos,
         (SELECT COUNT(*) FROM team_issues issue_item LEFT JOIN teams team ON team.team_id = issue_item.team_id WHERE team.team_id IS NULL) AS orphan_issues,
-        (SELECT COUNT(*)
-         FROM activity_documents activity_document
-         LEFT JOIN teams document_team ON document_team.team_id = activity_document.team_id
-         LEFT JOIN users document_creator ON document_creator.id = activity_document.author_id
-         LEFT JOIN users document_editor ON document_editor.id = activity_document.last_editor_id
-         WHERE document_team.team_id IS NULL
-           OR document_creator.id IS NULL
-           OR document_editor.id IS NULL) AS orphan_documents,
+        ${orphanDocumentsSelect},
         (SELECT COUNT(*)
          FROM teams sourced_team
          JOIN team_members sourced_member ON sourced_member.team_id = sourced_team.team_id AND sourced_member.user_id = 1

--- a/server/scripts/verifyDatabase.js
+++ b/server/scripts/verifyDatabase.js
@@ -13,6 +13,7 @@ const requiredTables = [
   'todos',
   'team_notices',
   'team_issues',
+  'activity_documents',
   'user_friendships',
   'direct_messages',
 ];
@@ -109,6 +110,14 @@ const run = async () => {
         (SELECT COUNT(*) FROM todos todo LEFT JOIN teams team ON team.team_id = todo.team_id WHERE team.team_id IS NULL) AS orphan_todos,
         (SELECT COUNT(*) FROM team_issues issue_item LEFT JOIN teams team ON team.team_id = issue_item.team_id WHERE team.team_id IS NULL) AS orphan_issues,
         (SELECT COUNT(*)
+         FROM activity_documents activity_document
+         LEFT JOIN teams document_team ON document_team.team_id = activity_document.team_id
+         LEFT JOIN users document_creator ON document_creator.id = activity_document.author_id
+         LEFT JOIN users document_editor ON document_editor.id = activity_document.last_editor_id
+         WHERE document_team.team_id IS NULL
+           OR document_creator.id IS NULL
+           OR document_editor.id IS NULL) AS orphan_documents,
+        (SELECT COUNT(*)
          FROM teams sourced_team
          JOIN team_members sourced_member ON sourced_member.team_id = sourced_team.team_id AND sourced_member.user_id = 1
          JOIN activitys sourced_activity ON sourced_activity.activity_id = sourced_team.source_id
@@ -142,7 +151,8 @@ const run = async () => {
       raw_snapshots: Number(missingRawItems.missing_raw_items || 0) === 0,
       relationships: Number(teamStats.orphan_memberships || 0) === 0
         && Number(teamStats.orphan_todos || 0) === 0
-        && Number(teamStats.orphan_issues || 0) === 0,
+        && Number(teamStats.orphan_issues || 0) === 0
+        && Number(teamStats.orphan_documents || 0) === 0,
       kim_sourced_team: Number(teamStats.kim_sourced_teams || 0) > 0,
       crawler: crawler?.status === 'completed' && Number(crawler?.error_count || 0) === 0,
       images: failedImages.length === 0 && Number(activityStats.sourced_without_images || 0) === 0,
@@ -166,6 +176,7 @@ const run = async () => {
         orphan_memberships: Number(teamStats.orphan_memberships || 0),
         orphan_todos: Number(teamStats.orphan_todos || 0),
         orphan_issues: Number(teamStats.orphan_issues || 0),
+        orphan_documents: Number(teamStats.orphan_documents || 0),
         kim_sourced_teams: Number(teamStats.kim_sourced_teams || 0),
       },
       crawler,

--- a/server/server.js
+++ b/server/server.js
@@ -82,6 +82,8 @@ const {
   ensureMessagingSchema,
   normalizeFriendshipPair,
 } = require('./messaging/service');
+const { createActivityDocumentsRouter } = require('./activity-documents/router');
+const { ensureActivityDocumentsSchema } = require('./activity-documents/service');
 
 const app = express();
 const PORT = Number(process.env.PORT || 3000);
@@ -285,6 +287,26 @@ const toClientUser = (user) => ({
 
 // Middleware 설정
 app.use(cors());
+app.use('/teams/:teamId/documents', (req, res, next) => {
+  res.setHeader('Cache-Control', 'private, no-store');
+  next();
+});
+app.use('/teams/:teamId/documents', bodyParser.json({ limit: '512kb' }));
+app.use('/teams/:teamId/documents', (error, req, res, next) => {
+  if (error?.type === 'entity.too.large') {
+    return res.status(413).json({
+      message: 'Markdown 문서 요청은 512KB 이하여야 합니다',
+      code: 'ACTIVITY_DOCUMENT_REQUEST_TOO_LARGE',
+    });
+  }
+  if (error instanceof SyntaxError && error.status === 400 && 'body' in error) {
+    return res.status(400).json({
+      message: '올바른 JSON 요청이 필요합니다',
+      code: 'INVALID_JSON_BODY',
+    });
+  }
+  return next(error);
+});
 app.use(bodyParser.json());
 app.use(attachAuth);
 app.use(requestLogger);
@@ -333,6 +355,10 @@ let feedbackSchemaReady = Promise.resolve();
 let curriculumSchemaReady = Promise.resolve();
 let activityDiscoverySchemaReady = Promise.resolve();
 let messagingSchemaReady = Promise.resolve();
+const activityDocumentSchemaReady = ensureActivityDocumentsSchema(portfolioDb);
+activityDocumentSchemaReady.catch((schemaError) => {
+  console.error('활동 문서 테이블 준비 오류:', schemaError);
+});
 let crawlerScheduler = null;
 
 const queuePortfolioJob = (job) => {
@@ -721,6 +747,13 @@ const portfolioArchiveTimer = setInterval(() => {
   }
 }, 60 * 60 * 1000);
 portfolioArchiveTimer.unref();
+
+app.use('/teams/:teamId/documents', createActivityDocumentsRouter({
+  database: portfolioDb,
+  getRequestUserId,
+  getSchemaReady: () => activityDocumentSchemaReady,
+  logError: (...args) => console.error(...args),
+}));
 
 // 기본 라우트
 app.get('/', (req, res) => {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -12,7 +12,9 @@
         "lucide-react": "^0.468.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-markdown": "^10.1.0",
         "react-router-dom": "^7.7.0",
+        "remark-gfm": "^4.0.1",
         "vite": "^7.0.0"
       },
       "devDependencies": {
@@ -1117,17 +1119,58 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "license": "MIT"
     },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1142,6 +1185,18 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.4.0.tgz",
+      "integrity": "sha512-1mEZtMKPM09vDmQt5y7YvmN2+DFTP7Tg0EWXdic8/C6VRnpb33e4ghisCIE3WZjsE2N8mf+QV1Zqh7ZFYLWInQ==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -1161,6 +1216,16 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/baseline-browser-mapping": {
@@ -1228,6 +1293,66 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -1251,7 +1376,6 @@
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
@@ -1269,6 +1393,41 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -1327,6 +1486,34 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1367,6 +1554,118 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -1397,6 +1696,16 @@
         "node": ">=6"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -1415,6 +1724,849 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1422,9 +2574,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -1448,6 +2600,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1467,9 +2644,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
-      "integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
+      "version": "8.5.28",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.28.tgz",
+      "integrity": "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A==",
       "funding": [
         {
           "type": "opencollective",
@@ -1486,12 +2663,22 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.18",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/react": {
@@ -1515,6 +2702,33 @@
         "react": "^19.2.8"
       }
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.17.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
@@ -1525,9 +2739,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
-      "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.3.tgz",
+      "integrity": "sha512-gyXgtdr5uACJ5b1Q4udzjVV+tb/rlHIMJKuJ0e89R4Kzgz47z/rgP0dIKxktqIEUhDHluGTPJJH/wRha7CyqsA==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -1547,12 +2761,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.18.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.1.tgz",
-      "integrity": "sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==",
+      "version": "7.18.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.3.tgz",
+      "integrity": "sha512-ytVbyBBM7vMfRCam25r0WMhSVSom909A8p+8m0/f1w853dz/xfFu6etAT2SEbVoSnI+ZoPRDqIsQXVT89gp7kg==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.18.1"
+        "react-router": "7.18.3"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -1560,6 +2774,72 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rollup": {
@@ -1636,6 +2916,48 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -1652,6 +2974,26 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1664,6 +3006,93 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -1694,6 +3123,34 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -1775,6 +3232,16 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "license": "ISC"
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -14,7 +14,9 @@
     "lucide-react": "^0.468.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-markdown": "^10.1.0",
     "react-router-dom": "^7.7.0",
+    "remark-gfm": "^4.0.1",
     "vite": "^7.0.0"
   },
   "devDependencies": {

--- a/web/src/activity-documents.css
+++ b/web/src/activity-documents.css
@@ -1,0 +1,151 @@
+/* Activity markdown documents */
+.activity-documents-page { max-width: 1420px; margin: 0 auto; }
+.document-page-header { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; margin-bottom: 20px; }
+.document-page-header .back-link { margin-bottom: 18px; }
+.document-page-header .back-link svg { width: 17px; }
+.document-page-header h1 { margin: 7px 0 6px; font-size: 29px; letter-spacing: -1.2px; }
+.document-page-header p { margin: 0; color: var(--text-sub); font-size: 15px; }
+.document-create-top { flex: 0 0 auto; }
+.document-inline-alert { display: grid; grid-template-columns: 22px minmax(0,1fr) auto; align-items: center; gap: 10px; margin-bottom: 12px; padding: 12px 14px; border: 1px solid #fedf89; border-radius: 12px; color: #93370d; background: #fffaeb; font-size: 14px; font-weight: 700; }
+.document-inline-alert.error { color: #b42318; border-color: #fecdca; background: #fef3f2; }
+.document-inline-alert.recovered { color: #175cd3; border-color: #b2ddff; background: #eff8ff; }
+.document-inline-alert svg { width: 18px; }
+.document-inline-alert button { display: inline-flex; align-items: center; gap: 5px; padding: 7px 9px; border: 0; border-radius: 8px; color: inherit; background: rgba(255,255,255,.8); font-weight: 900; }
+.document-inline-alert button svg { width: 14px; }
+.document-alert-actions { display: flex; gap: 6px; }
+.document-workspace { min-height: 690px; display: grid; grid-template-columns: 274px minmax(0,1fr); overflow: hidden; border: 1px solid var(--border); border-radius: 23px; background: #fff; box-shadow: var(--shadow); }
+.document-sidebar { min-width: 0; display: flex; flex-direction: column; border-right: 1px solid var(--border); background: #faf9fc; }
+.document-sidebar-title { display: flex; align-items: center; justify-content: space-between; padding: 18px 17px 13px; }
+.document-sidebar-title > div { display: flex; align-items: center; gap: 8px; }
+.document-sidebar-title svg { width: 18px; color: var(--primary); }
+.document-sidebar-title strong { font-size: 16px; }
+.document-sidebar-title > span { min-width: 26px; height: 26px; display: grid; place-items: center; padding: 0 6px; border-radius: 9px; color: var(--primary); background: var(--primary-soft); font-size: 13px; font-weight: 900; }
+.document-search { display: grid; grid-template-columns: 18px minmax(0,1fr); align-items: center; gap: 7px; margin: 0 13px 11px; padding: 0 11px; border: 1px solid #dedbe7; border-radius: 11px; background: #fff; }
+.document-search:focus-within { border-color: var(--primary); box-shadow: 0 0 0 3px var(--primary-soft); }
+.document-search svg { width: 16px; color: #9296a2; }
+.document-search input { min-width: 0; height: 41px; border: 0; outline: 0; color: #1d2433; background: transparent; font-size: 14px; }
+.document-list { min-height: 0; overflow-y: auto; padding: 0 8px 14px; }
+.document-list-item { position: relative; margin-bottom: 4px; border: 1px solid transparent; border-radius: 12px; }
+.document-list-item:hover { border-color: #e4dfff; background: #fff; }
+.document-list-item.active { border-color: #d9d1ff; background: #fff; box-shadow: 0 5px 18px rgba(73,45,151,.06); }
+.document-select { width: 100%; min-width: 0; display: grid; grid-template-columns: 30px minmax(0,1fr) 15px; align-items: center; gap: 8px; padding: 12px 36px 12px 9px; border: 0; border-radius: inherit; color: inherit; background: transparent; text-align: left; }
+.document-select > svg:first-child { width: 30px; height: 30px; padding: 8px; border-radius: 9px; color: #7965c9; background: #f2efff; }
+.document-select > svg:last-child { width: 14px; color: #b3b5bc; }
+.document-select span { min-width: 0; }
+.document-select strong, .document-select small { display: block; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.document-select strong { font-size: 14px; }
+.document-select small { margin-top: 3px; color: #8d919c; font-size: 12px; }
+.document-delete { position: absolute; right: 7px; top: 50%; width: 28px; height: 28px; display: none; place-items: center; border: 0; border-radius: 8px; color: #b42318; background: #fff1f0; transform: translateY(-50%); }
+.document-delete svg { width: 14px; }
+.document-list-item:hover .document-delete, .document-list-item:focus-within .document-delete { display: grid; }
+.document-list-item:hover .document-select > svg:last-child, .document-list-item:focus-within .document-select > svg:last-child { opacity: 0; }
+.document-list-empty { display: grid; justify-items: center; padding: 46px 14px; color: #9296a2; text-align: center; }
+.document-list-empty > svg { width: 28px; }
+.document-list-empty p { margin: 9px 0; font-size: 14px; }
+.document-list-empty button { border: 0; color: var(--primary); background: transparent; font-weight: 900; }
+.document-editor-shell { min-width: 0; display: flex; flex-direction: column; background: #fff; }
+.document-editor-empty { min-height: 650px; display: grid; justify-items: center; place-content: center; padding: 30px; color: #8d919c; text-align: center; }
+.document-editor-empty > svg { width: 52px; height: 52px; padding: 13px; border-radius: 17px; color: var(--primary); background: var(--primary-soft); }
+.document-editor-empty h2 { margin: 16px 0 6px; color: #1d2433; font-size: 20px; }
+.document-editor-empty p { margin: 0 0 17px; font-size: 14px; }
+.document-editor-head { min-height: 76px; display: flex; align-items: center; justify-content: space-between; gap: 18px; padding: 14px 19px; border-bottom: 1px solid #eeeef1; }
+.document-title-input { min-width: 0; width: 100%; padding: 6px 2px; border: 0; outline: 0; color: #171b24; background: transparent; font-size: 22px; font-weight: 900; letter-spacing: -.6px; }
+.document-title-input::placeholder { color: #b0b3bb; }
+.document-save-meta { flex: 0 0 auto; display: flex; align-items: center; gap: 8px; }
+.document-save-state { display: inline-flex; align-items: center; gap: 5px; color: #667085; font-size: 12px; font-weight: 800; white-space: nowrap; }
+.document-save-state.saved { color: #027a48; }
+.document-save-state.conflict, .document-save-state.error { color: #b42318; }
+.document-save-state svg { width: 15px; }
+.document-save-meta > button { min-height: 35px; display: inline-flex; align-items: center; gap: 5px; padding: 0 10px; border: 1px solid #ddd7f7; border-radius: 9px; color: var(--primary); background: #fff; font-size: 13px; font-weight: 900; }
+.document-save-meta > button svg { width: 14px; }
+.document-save-meta > button:disabled { color: #aaadb6; border-color: #e9e9ed; background: #f7f7f8; }
+.document-toolbar-row { min-height: 56px; display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 8px 14px; border-bottom: 1px solid #eeeef1; background: #fcfcfd; }
+.markdown-toolbar, .document-mode-switch { display: flex; align-items: center; gap: 3px; }
+.markdown-toolbar { overflow-x: auto; padding-bottom: 1px; }
+.markdown-toolbar button { width: 34px; height: 34px; display: grid; flex: 0 0 auto; place-items: center; border: 0; border-radius: 8px; color: #545966; background: transparent; }
+.markdown-toolbar button:hover, .markdown-toolbar button:focus-visible { color: var(--primary); background: var(--primary-soft); }
+.markdown-toolbar svg { width: 17px; }
+.document-mode-switch { flex: 0 0 auto; padding: 3px; border-radius: 10px; background: #efeff3; }
+.document-mode-switch button { min-height: 31px; display: inline-flex; align-items: center; gap: 5px; padding: 0 9px; border: 0; border-radius: 8px; color: #707480; background: transparent; font-size: 12px; font-weight: 800; }
+.document-mode-switch button.active { color: var(--primary); background: #fff; box-shadow: 0 2px 5px rgba(0,0,0,.06); }
+.document-mode-switch svg { width: 14px; }
+.document-canvas { min-height: 540px; display: grid; flex: 1; }
+.document-canvas.mode-split { grid-template-columns: repeat(2, minmax(0,1fr)); }
+.document-canvas.mode-edit, .document-canvas.mode-preview { grid-template-columns: minmax(0,1fr); }
+.document-editor-pane, .document-preview-pane { min-width: 0; display: flex; flex-direction: column; }
+.document-editor-pane { border-right: 1px solid #eeeef1; }
+.document-canvas.mode-edit .document-editor-pane { border-right: 0; }
+.document-pane-label { height: 34px; display: flex; flex: 0 0 auto; align-items: center; gap: 6px; padding: 0 15px; border-bottom: 1px solid #f1f1f3; color: #8a8e99; background: #fafafa; font-size: 11px; font-weight: 900; letter-spacing: .5px; text-transform: uppercase; }
+.document-pane-label svg { width: 13px; }
+.document-editor-pane textarea { min-height: 506px; flex: 1; padding: 24px; border: 0; outline: 0; color: #242936; background: #fff; font: 14px/1.85 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; resize: none; tab-size: 2; }
+.document-editor-pane textarea:focus { box-shadow: inset 0 0 0 2px rgba(122,90,248,.16); }
+.document-preview-pane { min-width: 0; overflow: hidden; }
+.markdown-preview { min-height: 506px; overflow: auto; flex: 1; padding: 26px 30px 48px; color: #343946; font-size: 15px; line-height: 1.8; overflow-wrap: anywhere; }
+.markdown-preview > :first-child { margin-top: 0; }
+.markdown-preview > :last-child { margin-bottom: 0; }
+.markdown-preview h1, .markdown-preview h2, .markdown-preview h3, .markdown-preview h4 { margin: 1.45em 0 .65em; color: #151922; line-height: 1.35; letter-spacing: -.5px; }
+.markdown-preview h1 { padding-bottom: 10px; border-bottom: 1px solid #e9e9ed; font-size: 28px; }
+.markdown-preview h2 { font-size: 22px; }
+.markdown-preview h3 { font-size: 18px; }
+.markdown-preview p { margin: 0 0 1em; }
+.markdown-preview ul, .markdown-preview ol { padding-left: 24px; }
+.markdown-preview li + li { margin-top: 4px; }
+.markdown-preview .contains-task-list { padding-left: 3px; list-style: none; }
+.markdown-preview .task-list-item { display: flex; align-items: flex-start; gap: 7px; }
+.markdown-preview .task-list-item input { width: 16px; height: 16px; flex: 0 0 auto; margin-top: 6px; accent-color: var(--primary); }
+.markdown-preview blockquote { margin: 18px 0; padding: 9px 16px; border-left: 4px solid #a48cff; color: #5d6270; background: #faf9ff; }
+.markdown-preview blockquote p { margin: 0; }
+.markdown-preview code { padding: 2px 5px; border-radius: 5px; color: #6941c6; background: #f4f1ff; font: .9em/1.6 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+.markdown-preview pre { overflow-x: auto; padding: 17px; border-radius: 12px; color: #e4e7ec; background: #24212e; }
+.markdown-preview pre code { padding: 0; color: inherit; background: transparent; }
+.markdown-preview a { color: #6941c6; font-weight: 700; text-decoration: underline; text-underline-offset: 3px; }
+.markdown-preview hr { margin: 28px 0; border: 0; border-top: 1px solid #e4e7ec; }
+.markdown-preview table { width: max-content; min-width: 100%; margin: 18px 0; border-collapse: collapse; font-size: 14px; }
+.markdown-preview th, .markdown-preview td { min-width: 105px; padding: 9px 11px; border: 1px solid #dddfe5; text-align: left; }
+.markdown-preview th { color: #3f4450; background: #f6f5f9; font-weight: 900; }
+.markdown-empty { color: #9a9da7; }
+.document-editor-footer { display: flex; align-items: center; justify-content: space-between; gap: 15px; padding: 10px 17px; border-top: 1px solid #eeeef1; color: #8b8f99; background: #fcfcfd; font-size: 11px; }
+.spin { animation: document-spin .8s linear infinite; }
+@keyframes document-spin { to { transform: rotate(360deg); } }
+@media (prefers-reduced-motion: reduce) { .activity-documents-page .spin { animation: none; } }
+@media (hover: none), (pointer: coarse) {
+  .document-delete { display: grid; }
+  .document-list-item .document-select > svg:last-child { opacity: 0; }
+}
+
+@media (max-width: 1050px) {
+  .document-workspace { grid-template-columns: 230px minmax(0,1fr); }
+  .document-mode-switch button { padding-inline: 7px; }
+  .document-mode-switch button svg { display: none; }
+  .markdown-preview { padding-inline: 22px; }
+}
+
+@media (max-width: 900px) {
+  .document-workspace { grid-template-columns: 1fr; }
+  .document-sidebar { max-height: 270px; border-right: 0; border-bottom: 1px solid var(--border); }
+  .document-list { display: grid; grid-template-columns: repeat(2, minmax(0,1fr)); gap: 4px; }
+  .document-list-empty { grid-column: 1 / -1; padding: 24px; }
+}
+
+@media (max-width: 720px) {
+  .document-page-header { align-items: stretch; flex-direction: column; }
+  .document-page-header h1 { font-size: 25px; }
+  .document-create-top { width: 100%; }
+  .document-workspace { min-height: 0; border-radius: 18px; }
+  .document-sidebar { max-height: 300px; }
+  .document-list { grid-template-columns: 1fr; }
+  .document-editor-head { align-items: flex-start; flex-direction: column; gap: 7px; padding: 13px 15px; }
+  .document-title-input { font-size: 20px; }
+  .document-save-meta { width: 100%; justify-content: space-between; }
+  .document-toolbar-row { align-items: stretch; flex-direction: column; }
+  .document-mode-switch { display: grid; grid-template-columns: repeat(3,1fr); }
+  .document-mode-switch button { justify-content: center; }
+  .document-mode-switch button svg { display: block; }
+  .document-canvas.mode-split { grid-template-columns: 1fr; }
+  .document-canvas.mode-split .document-editor-pane { border-right: 0; border-bottom: 1px solid #eeeef1; }
+  .document-editor-pane textarea, .markdown-preview { min-height: 380px; }
+  .document-preview-pane { min-height: 430px; }
+  .document-editor-footer { align-items: flex-start; flex-direction: column; gap: 4px; }
+  .document-inline-alert { grid-template-columns: 20px 1fr; }
+  .document-inline-alert button, .document-alert-actions { grid-column: 2; justify-self: start; }
+}

--- a/web/src/app/AppRoutes.tsx
+++ b/web/src/app/AppRoutes.tsx
@@ -1,3 +1,4 @@
+import { lazy, Suspense } from 'react';
 import { Navigate, Route, Routes, useLocation, useParams } from 'react-router-dom';
 import { ActivityPage } from '../pages/ActivityPage';
 import { ActivityManagePage } from '../pages/ActivityManagePage';
@@ -21,8 +22,12 @@ import { AccountSettingsPage, ActivityArchivePage, AwardsPage, FavoritesPage, Fe
 import { AdminOperationsPage } from '../pages/AdminOperationsPage';
 import { MessagesPage } from '../pages/MessagesPage';
 import { SearchResultsPage } from '../pages/SearchResultsPage';
+import { PageState } from '../shared/ui/PageState';
 import { useAuth } from './AuthContext';
 import { AppShell } from './AppShell';
+
+const ActivityDocumentsPage = lazy(() => import('../pages/ActivityDocumentsPage')
+  .then((module) => ({ default: module.ActivityDocumentsPage })));
 
 function RequireAuth({ children }: { children: React.ReactNode }) {
   const { user } = useAuth();
@@ -56,6 +61,7 @@ export function AppRoutes() {
       <Route path="matching/:id/edit" element={<RequireAuth><RecruitmentEditorPage /></RequireAuth>} />
       <Route path="activity" element={<RequireAuth><ActivityPage /></RequireAuth>} />
       <Route path="activity/:teamId/manage" element={<RequireAuth><ActivityManagePage /></RequireAuth>} />
+      <Route path="activity/:teamId/documents" element={<RequireAuth><Suspense fallback={<PageState loading />}><ActivityDocumentsPage /></Suspense></RequireAuth>} />
       <Route path="notifications" element={<RequireAuth><NotificationsPage /></RequireAuth>} />
       <Route path="messages" element={<RequireAuth><MessagesPage /></RequireAuth>} />
       <Route path="mypage" element={<RequireAuth><MyPage /></RequireAuth>} />

--- a/web/src/pages/ActivityDocumentsPage.tsx
+++ b/web/src/pages/ActivityDocumentsPage.tsx
@@ -1,0 +1,617 @@
+import {
+  AlertTriangle,
+  ArrowLeft,
+  Bold,
+  Check,
+  CheckSquare,
+  ChevronRight,
+  Cloud,
+  CloudOff,
+  Code2,
+  Eye,
+  FilePlus2,
+  Files,
+  Heading2,
+  Link2,
+  List,
+  LoaderCircle,
+  PencilLine,
+  Quote,
+  RefreshCw,
+  Save,
+  Search,
+  SplitSquareHorizontal,
+  Table2,
+  Trash2,
+} from 'lucide-react';
+import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import Markdown from 'react-markdown';
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import remarkGfm from 'remark-gfm';
+import { ApiError, api } from '../shared/api/client';
+import type { ActivityDocument, TeamSummary } from '../shared/types/domain';
+import { PageState } from '../shared/ui/PageState';
+import '../activity-documents.css';
+
+type EditorMode = 'edit' | 'split' | 'preview';
+type SaveState = 'saved' | 'dirty' | 'saving' | 'conflict' | 'error';
+type ApiDocument = Omit<ActivityDocument, 'content_markdown'> & {
+  content_markdown?: string;
+  markdown_content?: string;
+};
+
+const DEFAULT_DOCUMENT = '# 새 문서\n\n활동 기록을 작성해보세요.';
+const DRAFT_STORAGE_PREFIX = 'kkiri-activity-document-draft';
+
+const normalizeDocument = (document: ApiDocument): ActivityDocument => ({
+  ...document,
+  content_markdown: document.content_markdown ?? document.markdown_content ?? '',
+});
+
+const dateTime = (value?: string) => value
+  ? new Intl.DateTimeFormat('ko-KR', { dateStyle: 'medium', timeStyle: 'short' }).format(new Date(value))
+  : '';
+
+const saveStateCopy: Record<SaveState, { label: string }> = {
+  saved: { label: '모든 변경사항 저장됨' },
+  dirty: { label: '저장 대기 중' },
+  saving: { label: '저장 중' },
+  conflict: { label: '편집 충돌' },
+  error: { label: '저장 실패' },
+};
+
+function SaveStateIcon({ state }: { state: SaveState }) {
+  if (state === 'saved') return <Check />;
+  if (state === 'dirty') return <Cloud />;
+  if (state === 'saving') return <LoaderCircle className="spin" />;
+  if (state === 'conflict') return <AlertTriangle />;
+  return <CloudOff />;
+}
+
+const draftStorageKey = (document: Pick<ActivityDocument, 'team_id' | 'document_id'>) => `${DRAFT_STORAGE_PREFIX}:${document.team_id}:${document.document_id}`;
+
+const storeDraft = (document: ActivityDocument) => {
+  try {
+    sessionStorage.setItem(draftStorageKey(document), JSON.stringify({
+      title: document.title,
+      content_markdown: document.content_markdown,
+      version: document.version,
+    }));
+  } catch {
+    // Storage can be disabled by the browser; autosave remains the primary path.
+  }
+};
+
+const clearStoredDraft = (document: Pick<ActivityDocument, 'team_id' | 'document_id'>) => {
+  try { sessionStorage.removeItem(draftStorageKey(document)); } catch { /* Ignore unavailable storage. */ }
+};
+
+const readStoredDraft = (document: ActivityDocument) => {
+  try {
+    const raw = sessionStorage.getItem(draftStorageKey(document));
+    if (!raw) return null;
+    const value = JSON.parse(raw) as { title?: unknown; content_markdown?: unknown; version?: unknown };
+    if (typeof value.title !== 'string' || typeof value.content_markdown !== 'string' || typeof value.version !== 'number') return null;
+    if (value.title === document.title && value.content_markdown === document.content_markdown) {
+      clearStoredDraft(document);
+      return null;
+    }
+    return value as Pick<ActivityDocument, 'title' | 'content_markdown' | 'version'>;
+  } catch {
+    return null;
+  }
+};
+
+function SafeMarkdownLink({ href, children }: React.ComponentPropsWithoutRef<'a'>) {
+  const safe = !href
+    || (href.startsWith('/') && !href.startsWith('//'))
+    || href.startsWith('./')
+    || href.startsWith('../')
+    || href.startsWith('#')
+    || /^https?:\/\//i.test(href)
+    || /^mailto:/i.test(href);
+  if (!safe) return <span>{children}</span>;
+  const external = /^https?:\/\//i.test(href || '');
+  return <a href={href} target={external ? '_blank' : undefined} rel={external ? 'noopener noreferrer' : undefined}>{children}</a>;
+}
+
+export function ActivityDocumentsPage() {
+  const { teamId: teamIdParam } = useParams();
+  const teamId = Number(teamIdParam);
+  const navigate = useNavigate();
+  const [team, setTeam] = useState<TeamSummary | null>(null);
+  const [documents, setDocuments] = useState<ActivityDocument[]>([]);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [draft, setDraft] = useState<ActivityDocument | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [mode, setMode] = useState<EditorMode>('split');
+  const [loading, setLoading] = useState(true);
+  const [documentLoading, setDocumentLoading] = useState(false);
+  const [pageError, setPageError] = useState('');
+  const [saveState, setSaveState] = useState<SaveState>('saved');
+  const [saveError, setSaveError] = useState('');
+  const [draftCopied, setDraftCopied] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const draftRef = useRef<ActivityDocument | null>(null);
+  const saveStateRef = useRef<SaveState>('saved');
+  const savingRef = useRef(false);
+  const queuedSaveRef = useRef(false);
+  const documentRequestRef = useRef(0);
+  const deferredMarkdown = useDeferredValue(draft?.content_markdown ?? '');
+
+  useEffect(() => { draftRef.current = draft; }, [draft]);
+  useEffect(() => { saveStateRef.current = saveState; }, [saveState]);
+
+  const openDocument = useCallback((document: ActivityDocument | null, ignoreStoredDraft = false) => {
+    const stored = document && !ignoreStoredDraft ? readStoredDraft(document) : null;
+    if (document && ignoreStoredDraft) clearStoredDraft(document);
+    const nextDocument = document && stored ? { ...document, ...stored } : document;
+    setSelectedId(document?.document_id ?? null);
+    setDraft(nextDocument ? { ...nextDocument } : null);
+    draftRef.current = nextDocument ? { ...nextDocument } : null;
+    setSaveError(stored ? '브라우저에 남아 있던 저장 전 초안을 복구했습니다.' : '');
+    setDraftCopied(false);
+    const nextState: SaveState = stored ? 'dirty' : 'saved';
+    setSaveState(nextState);
+    saveStateRef.current = nextState;
+  }, []);
+
+  const loadDocuments = useCallback(async (preferredId?: number) => {
+    if (!Number.isFinite(teamId) || teamId <= 0) {
+      setPageError('올바르지 않은 활동 주소입니다.');
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setPageError('');
+    const requestId = ++documentRequestRef.current;
+    try {
+      const [teams, result] = await Promise.all([
+        api<TeamSummary[]>('/my-teams'),
+        api<ApiDocument[]>(`/teams/${teamId}/documents`),
+      ]);
+      if (requestId !== documentRequestRef.current) return;
+      let nextDocuments = result.map(normalizeDocument);
+      setTeam(teams.find((item) => item.team_id === teamId) ?? null);
+      const nextId = preferredId ?? selectedId;
+      const selectedMeta = nextDocuments.find((item) => item.document_id === nextId) ?? nextDocuments[0] ?? null;
+      if (selectedMeta) {
+        const detail = normalizeDocument(await api<ApiDocument>(`/teams/${teamId}/documents/${selectedMeta.document_id}`));
+        if (requestId !== documentRequestRef.current) return;
+        const selectedDocument = { ...selectedMeta, ...detail };
+        nextDocuments = nextDocuments.map((item) => item.document_id === selectedDocument.document_id ? selectedDocument : item);
+        setDocuments(nextDocuments);
+        openDocument(selectedDocument);
+      } else {
+        setDocuments([]);
+        openDocument(null);
+      }
+    } catch (reason) {
+      if (requestId !== documentRequestRef.current) return;
+      setPageError(reason instanceof Error ? reason.message : '문서를 불러오지 못했습니다.');
+    } finally {
+      if (requestId === documentRequestRef.current) setLoading(false);
+    }
+  }, [openDocument, selectedId, teamId]);
+
+  // 팀이 바뀔 때만 새 목록과 선택 문서를 가져옵니다.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(() => { loadDocuments(); }, [teamId]);
+
+  const saveDraft = useCallback(async (snapshot = draftRef.current) => {
+    if (!snapshot) return false;
+    if (savingRef.current) {
+      queuedSaveRef.current = true;
+      return false;
+    }
+    savingRef.current = true;
+    setSaveState('saving');
+    saveStateRef.current = 'saving';
+    setSaveError('');
+    try {
+      const requestSnapshot = { ...snapshot, title: snapshot.title.trim() || '제목 없는 문서' };
+      const result = await api<ApiDocument>(`/teams/${snapshot.team_id}/documents/${snapshot.document_id}`, {
+        method: 'PUT',
+        body: JSON.stringify({
+          title: requestSnapshot.title,
+          content_markdown: requestSnapshot.content_markdown,
+          version: requestSnapshot.version,
+        }),
+      });
+      const saved = normalizeDocument(result);
+      const nextVersion = saved.version ?? requestSnapshot.version + 1;
+      setDocuments((current) => current.map((item) => item.document_id === snapshot.document_id
+        ? { ...item, ...saved, content_markdown: requestSnapshot.content_markdown, version: nextVersion }
+        : item));
+      const latestDraft = draftRef.current;
+      let currentSnapshotSaved = true;
+      if (latestDraft?.document_id === snapshot.document_id) {
+        const unchanged = latestDraft.title === snapshot.title
+          && latestDraft.content_markdown === snapshot.content_markdown;
+        currentSnapshotSaved = unchanged;
+        const nextDraft = {
+          ...latestDraft,
+          title: unchanged ? saved.title : latestDraft.title,
+          version: nextVersion,
+          updated_at: saved.updated_at || latestDraft.updated_at,
+        };
+        draftRef.current = nextDraft;
+        setDraft(nextDraft);
+        const nextState: SaveState = unchanged ? 'saved' : 'dirty';
+        setSaveState(nextState);
+        saveStateRef.current = nextState;
+        if (unchanged) clearStoredDraft(nextDraft);
+      }
+      return currentSnapshotSaved;
+    } catch (reason) {
+      const conflict = reason instanceof ApiError && (reason.status === 409 || reason.code === 'DOCUMENT_VERSION_CONFLICT');
+      const nextState: SaveState = conflict ? 'conflict' : 'error';
+      setSaveState(nextState);
+      saveStateRef.current = nextState;
+      setSaveError(conflict
+        ? '다른 팀원이 이 문서를 먼저 저장했습니다. 내 내용을 보존한 뒤 최신 버전을 불러오세요.'
+        : reason instanceof Error ? reason.message : '문서를 저장하지 못했습니다.');
+      return false;
+    } finally {
+      savingRef.current = false;
+      const shouldRunQueuedSave = queuedSaveRef.current && saveStateRef.current === 'dirty';
+      queuedSaveRef.current = false;
+      if (shouldRunQueuedSave) {
+        window.setTimeout(() => { saveDraft(draftRef.current); }, 0);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    if (saveState !== 'dirty' || !draftRef.current) return undefined;
+    const timer = window.setTimeout(() => { saveDraft(); }, 900);
+    return () => window.clearTimeout(timer);
+  }, [draft, saveDraft, saveState]);
+
+  useEffect(() => {
+    const warnBeforeUnload = (event: BeforeUnloadEvent) => {
+      if (!['dirty', 'saving', 'conflict', 'error'].includes(saveStateRef.current)) return;
+      if (draftRef.current) storeDraft(draftRef.current);
+      event.preventDefault();
+    };
+    const backupBeforeHistoryChange = () => {
+      if (draftRef.current && ['dirty', 'saving', 'conflict', 'error'].includes(saveStateRef.current)) storeDraft(draftRef.current);
+    };
+    window.addEventListener('beforeunload', warnBeforeUnload);
+    window.addEventListener('popstate', backupBeforeHistoryChange);
+    return () => {
+      window.removeEventListener('beforeunload', warnBeforeUnload);
+      window.removeEventListener('popstate', backupBeforeHistoryChange);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (saveState !== 'dirty' || !draft) return undefined;
+    const timer = window.setTimeout(() => storeDraft(draft), 180);
+    return () => window.clearTimeout(timer);
+  }, [draft, saveState]);
+
+  const updateDraft = (changes: Partial<Pick<ActivityDocument, 'title' | 'content_markdown'>>) => {
+    setDraft((current) => {
+      if (!current) return current;
+      const next = { ...current, ...changes };
+      draftRef.current = next;
+      return next;
+    });
+    if ('title' in changes) {
+      setDocuments((current) => current.map((item) => item.document_id === selectedId ? { ...item, ...changes } : item));
+    }
+    setSaveState('dirty');
+    saveStateRef.current = 'dirty';
+    setSaveError('');
+  };
+
+  const selectDocument = async (document: ActivityDocument) => {
+    if (document.document_id === selectedId) return;
+    if (saveStateRef.current === 'saving') return;
+    if (saveStateRef.current === 'dirty') {
+      const saved = await saveDraft();
+      if (!saved) return;
+    } else if (['conflict', 'error'].includes(saveStateRef.current)) {
+      // eslint-disable-next-line no-alert
+      if (!window.confirm('저장되지 않은 변경사항을 버리고 다른 문서로 이동할까요?')) return;
+      if (draftRef.current) clearStoredDraft(draftRef.current);
+    }
+    setDocumentLoading(true);
+    setPageError('');
+    const requestId = ++documentRequestRef.current;
+    try {
+      const detail = normalizeDocument(await api<ApiDocument>(`/teams/${teamId}/documents/${document.document_id}`));
+      if (requestId !== documentRequestRef.current) return;
+      const selectedDocument = { ...document, ...detail };
+      setDocuments((current) => current.map((item) => item.document_id === document.document_id ? selectedDocument : item));
+      openDocument(selectedDocument);
+    } catch (reason) {
+      if (requestId !== documentRequestRef.current) return;
+      setPageError(reason instanceof Error ? reason.message : '문서를 불러오지 못했습니다.');
+    } finally {
+      if (requestId === documentRequestRef.current) setDocumentLoading(false);
+    }
+  };
+
+  const createDocument = async () => {
+    if (saveStateRef.current === 'saving') return;
+    if (saveStateRef.current === 'dirty' && !(await saveDraft())) return;
+    const preserveDraft = draftRef.current && ['conflict', 'error'].includes(saveStateRef.current);
+    const draftToPreserve = preserveDraft ? draftRef.current : null;
+    if (preserveDraft) {
+      // eslint-disable-next-line no-alert
+      if (!window.confirm('저장되지 않은 현재 초안을 복구 문서로 보존하고 새 문서를 만들까요?')) return;
+    }
+    setCreating(true);
+    setPageError('');
+    try {
+      const result = await api<ApiDocument>(`/teams/${teamId}/documents`, {
+        method: 'POST',
+        body: JSON.stringify({
+          title: draftToPreserve ? `${draftToPreserve.title || '제목 없는 문서'} (복구본)`.slice(0, 160) : '제목 없는 문서',
+          content_markdown: draftToPreserve ? draftToPreserve.content_markdown : DEFAULT_DOCUMENT,
+        }),
+      });
+      const created = normalizeDocument(result);
+      if (draftToPreserve) clearStoredDraft(draftToPreserve);
+      setDocuments((current) => [created, ...current]);
+      openDocument(created);
+      window.requestAnimationFrame(() => textareaRef.current?.focus());
+    } catch (reason) {
+      setPageError(reason instanceof Error ? reason.message : '새 문서를 만들지 못했습니다.');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const deleteDocument = async (document: ActivityDocument) => {
+    let target = document;
+    if (document.document_id === selectedId) {
+      if (saveStateRef.current === 'saving') return;
+      if (saveStateRef.current === 'dirty') {
+        if (!(await saveDraft())) return;
+        target = draftRef.current ?? document;
+      }
+      if (['conflict', 'error'].includes(saveStateRef.current)) {
+        setSaveError('저장되지 않은 초안을 보존하거나 최신본을 불러온 뒤 삭제해주세요.');
+        return;
+      }
+    }
+    // eslint-disable-next-line no-alert
+    if (!window.confirm(`“${target.title || '제목 없는 문서'}” 문서를 삭제할까요? 이 작업은 되돌릴 수 없습니다.`)) return;
+    try {
+      await api(`/teams/${teamId}/documents/${target.document_id}`, {
+        method: 'DELETE',
+        body: JSON.stringify({ version: target.version }),
+      });
+      const remaining = documents.filter((item) => item.document_id !== document.document_id);
+      clearStoredDraft(target);
+      setDocuments(remaining);
+      setPageError('');
+      if (document.document_id === selectedId) {
+        // 목록 응답에는 본문이 없으므로 다음 문서는 상세 조회를 거쳐 열어야 합니다.
+        openDocument(null);
+        if (remaining[0]) await selectDocument(remaining[0]);
+      }
+    } catch (reason) {
+      const conflict = reason instanceof ApiError && (reason.status === 409 || reason.code === 'DOCUMENT_VERSION_CONFLICT');
+      const message = conflict
+        ? '다른 팀원이 문서를 수정해 삭제하지 못했습니다. 최신 목록을 불러오세요.'
+        : reason instanceof Error ? reason.message : '문서를 삭제하지 못했습니다.';
+      if (document.document_id === selectedId) {
+        setSaveError(message);
+        if (conflict) {
+          setSaveState('conflict');
+          saveStateRef.current = 'conflict';
+        }
+      } else {
+        // 다른 목록 항목의 삭제 실패가 현재 편집 중인 문서 상태를 오염시키지 않게 합니다.
+        setPageError(message);
+      }
+    }
+  };
+
+  const reloadConflictedDocument = async () => {
+    if (!selectedId) return;
+    // eslint-disable-next-line no-alert
+    if (!window.confirm('서버의 최신본을 불러오면 화면의 로컬 초안이 대체됩니다. 계속할까요?')) return;
+    setLoading(true);
+    const requestId = ++documentRequestRef.current;
+    try {
+      const result = await api<ApiDocument>(`/teams/${teamId}/documents/${selectedId}`);
+      if (requestId !== documentRequestRef.current) return;
+      const latest = normalizeDocument(result);
+      setDocuments((current) => current.map((item) => item.document_id === selectedId ? latest : item));
+      openDocument(latest, true);
+    } catch (reason) {
+      if (requestId !== documentRequestRef.current) return;
+      setSaveError(reason instanceof Error ? reason.message : '최신 문서를 불러오지 못했습니다.');
+    } finally {
+      if (requestId === documentRequestRef.current) setLoading(false);
+    }
+  };
+
+  const copyLocalDraft = async () => {
+    if (!draftRef.current) return;
+    try {
+      await navigator.clipboard.writeText(`${draftRef.current.title}\n\n${draftRef.current.content_markdown}`);
+      setDraftCopied(true);
+    } catch {
+      setSaveError('클립보드에 복사하지 못했습니다. 편집기에서 직접 내용을 복사해주세요.');
+    }
+  };
+
+  const insertMarkdown = (kind: 'heading' | 'bold' | 'list' | 'check' | 'quote' | 'code' | 'link' | 'table') => {
+    if (!draft) return;
+    const textarea = textareaRef.current;
+    const start = textarea?.selectionStart ?? draft.content_markdown.length;
+    const end = textarea?.selectionEnd ?? start;
+    const selected = draft.content_markdown.slice(start, end);
+    let insertion = '';
+    let selectionOffset = 0;
+    let selectionLength = 0;
+    if (kind === 'heading') insertion = `## ${selected || '제목'}`;
+    if (kind === 'bold') {
+      insertion = `**${selected || '강조할 내용'}**`;
+      selectionOffset = 2;
+      selectionLength = selected.length || 6;
+    }
+    if (kind === 'list') insertion = (selected || '목록 항목').split('\n').map((line) => `- ${line}`).join('\n');
+    if (kind === 'check') insertion = (selected || '할 일').split('\n').map((line) => `- [ ] ${line}`).join('\n');
+    if (kind === 'quote') insertion = (selected || '인용문').split('\n').map((line) => `> ${line}`).join('\n');
+    if (kind === 'code') insertion = selected.includes('\n') ? `\n\`\`\`\n${selected || '코드'}\n\`\`\`\n` : `\`${selected || '코드'}\``;
+    if (kind === 'link') {
+      insertion = `[${selected || '링크 제목'}](https://)`;
+      selectionOffset = insertion.lastIndexOf('https://');
+      selectionLength = 8;
+    }
+    if (kind === 'table') insertion = '\n| 항목 | 담당자 | 상태 |\n| --- | --- | --- |\n| 예시 | 이름 | 진행 중 |\n';
+    const next = `${draft.content_markdown.slice(0, start)}${insertion}${draft.content_markdown.slice(end)}`;
+    updateDraft({ content_markdown: next });
+    window.requestAnimationFrame(() => {
+      textarea?.focus();
+      const nextStart = start + selectionOffset;
+      textarea?.setSelectionRange(nextStart, nextStart + (selectionLength || insertion.length));
+    });
+  };
+
+  useEffect(() => {
+    const guardInternalNavigation = (event: MouseEvent) => {
+      if (event.defaultPrevented || event.button !== 0 || event.ctrlKey || event.metaKey || event.shiftKey || event.altKey) return;
+      const target = event.target instanceof Element ? event.target.closest<HTMLAnchorElement>('a[href]') : null;
+      if (!target || target.target === '_blank') return;
+      const destination = new URL(target.href, window.location.href);
+      if (destination.origin !== window.location.origin || destination.href === window.location.href) return;
+      if (saveStateRef.current === 'saving') {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        return;
+      }
+      if (saveStateRef.current === 'dirty') {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        saveDraft().then((saved) => {
+          if (saved) navigate(`${destination.pathname}${destination.search}${destination.hash}`);
+        });
+        return;
+      }
+      if (['conflict', 'error'].includes(saveStateRef.current)) {
+        // eslint-disable-next-line no-alert
+        if (!window.confirm('저장되지 않은 초안을 버리고 다른 화면으로 이동할까요?')) {
+          event.preventDefault();
+          event.stopImmediatePropagation();
+        } else if (draftRef.current) {
+          clearStoredDraft(draftRef.current);
+        }
+      }
+    };
+    window.addEventListener('click', guardInternalNavigation, true);
+    return () => window.removeEventListener('click', guardInternalNavigation, true);
+  }, [navigate, saveDraft]);
+
+  const filteredDocuments = useMemo(() => {
+    const query = searchQuery.trim().toLocaleLowerCase('ko-KR');
+    if (!query) return documents;
+    return documents.filter((document) => document.title.toLocaleLowerCase('ko-KR').includes(query));
+  }, [documents, searchQuery]);
+
+  if (loading && !documents.length) return <PageState loading />;
+  if (pageError && !documents.length) return <PageState error={pageError} />;
+
+  return <div className="activity-documents-page">
+    <header className="document-page-header">
+      <div>
+        <Link className="back-link" to={`/activity?team=${teamId}`}><ArrowLeft /> 활동으로 돌아가기</Link>
+        <span className="eyebrow">ACTIVITY DOCUMENTS</span>
+        <h1>{team?.team_name || '활동 문서'}</h1>
+        <p>아이디어, 회의록, 조사 자료를 Markdown으로 함께 작성하고 활동별로 보관하세요.</p>
+      </div>
+      <button className="primary-button document-create-top" onClick={() => { createDocument(); }} disabled={creating}>
+        {creating ? <LoaderCircle className="spin" /> : <FilePlus2 />} 새 문서
+      </button>
+    </header>
+
+    {pageError && <div className="document-inline-alert error" role="alert"><CloudOff /><span>{pageError}</span><button type="button" onClick={() => { loadDocuments(selectedId ?? undefined); }}>다시 시도</button></div>}
+
+    <div className="document-workspace">
+      <aside className="document-sidebar" aria-label="활동 문서 목록">
+        <div className="document-sidebar-title"><div><Files /><strong>문서</strong></div><span>{documents.length}</span></div>
+        <label className="document-search"><Search /><span className="sr-only">문서 검색</span><input value={searchQuery} onChange={(event) => setSearchQuery(event.target.value)} placeholder="문서 제목 검색" /></label>
+        <div className="document-list">
+          {filteredDocuments.map((document) => <div className={`document-list-item ${document.document_id === selectedId ? 'active' : ''}`} key={document.document_id}>
+            <button className="document-select" onClick={() => { selectDocument(document); }} aria-current={document.document_id === selectedId ? 'page' : undefined}>
+              <PencilLine />
+              <span><strong>{document.title || '제목 없는 문서'}</strong><small>{dateTime(document.updated_at)} · v{document.version}</small></span>
+              <ChevronRight />
+            </button>
+            <button className="document-delete" aria-label={`${document.title || '제목 없는 문서'} 삭제`} onClick={() => { deleteDocument(document); }}><Trash2 /></button>
+          </div>)}
+          {!filteredDocuments.length && <div className="document-list-empty"><Files /><p>{documents.length ? '검색 결과가 없습니다.' : '첫 문서를 만들어보세요.'}</p>{!documents.length && <button onClick={() => { createDocument(); }}>새 문서 만들기</button>}</div>}
+        </div>
+      </aside>
+
+      <section className="document-editor-shell" aria-label="활동 문서 편집 영역">
+        {documentLoading ? <div className="document-editor-empty"><LoaderCircle className="spin" /><h2>문서를 불러오는 중입니다</h2></div> : !draft ? <div className="document-editor-empty"><Files /><h2>작성할 문서를 선택하세요</h2><p>활동의 모든 기록을 팀원과 같은 공간에서 관리할 수 있습니다.</p><button className="primary-button" onClick={() => { createDocument(); }}><FilePlus2 /> 첫 문서 만들기</button></div> : <>
+          <div className="document-editor-head">
+            <input className="document-title-input" value={draft.title} maxLength={160} onChange={(event) => updateDraft({ title: event.target.value })} aria-label="문서 제목" placeholder="문서 제목" />
+            <div className="document-save-meta">
+              <span className={`document-save-state ${saveState}`} role="status" aria-live="polite"><SaveStateIcon state={saveState} />{saveStateCopy[saveState].label}</span>
+              <button onClick={() => { saveDraft(); }} disabled={saveState === 'saving' || saveState === 'saved'} aria-label="지금 저장"><Save /> 저장</button>
+            </div>
+          </div>
+
+          {saveError && <div className={`document-inline-alert ${saveState === 'conflict' ? 'conflict' : saveState === 'dirty' ? 'recovered' : 'error'}`} role="alert">
+            <AlertTriangle /><span>{saveError}</span>
+            {saveState === 'conflict' && <div className="document-alert-actions"><button type="button" onClick={() => { copyLocalDraft(); }}><Files /> {draftCopied ? '초안 복사됨' : '내 초안 복사'}</button><button type="button" onClick={() => { createDocument(); }}><FilePlus2 /> 복구본 만들기</button><button type="button" onClick={() => { reloadConflictedDocument(); }}><RefreshCw /> 최신본 불러오기</button></div>}
+            {saveState === 'error' && <button onClick={() => { saveDraft(); }}><RefreshCw /> 다시 저장</button>}
+          </div>}
+
+          <div className="document-toolbar-row">
+            <div className="markdown-toolbar" role="toolbar" aria-label="Markdown 서식 도구">
+              <button type="button" onClick={() => insertMarkdown('heading')} aria-label="제목 추가" title="제목"><Heading2 /></button>
+              <button type="button" onClick={() => insertMarkdown('bold')} aria-label="굵게" title="굵게"><Bold /></button>
+              <button type="button" onClick={() => insertMarkdown('list')} aria-label="글머리 기호 목록" title="목록"><List /></button>
+              <button type="button" onClick={() => insertMarkdown('check')} aria-label="체크리스트" title="체크리스트"><CheckSquare /></button>
+              <button type="button" onClick={() => insertMarkdown('quote')} aria-label="인용문" title="인용문"><Quote /></button>
+              <button type="button" onClick={() => insertMarkdown('code')} aria-label="코드" title="코드"><Code2 /></button>
+              <button type="button" onClick={() => insertMarkdown('link')} aria-label="링크" title="링크"><Link2 /></button>
+              <button type="button" onClick={() => insertMarkdown('table')} aria-label="표 템플릿" title="표"><Table2 /></button>
+            </div>
+            <div className="document-mode-switch" role="group" aria-label="편집 화면 모드">
+              <button type="button" className={mode === 'edit' ? 'active' : ''} onClick={() => setMode('edit')} aria-pressed={mode === 'edit'}><PencilLine /> 편집</button>
+              <button type="button" className={mode === 'split' ? 'active' : ''} onClick={() => setMode('split')} aria-pressed={mode === 'split'}><SplitSquareHorizontal /> 분할</button>
+              <button type="button" className={mode === 'preview' ? 'active' : ''} onClick={() => setMode('preview')} aria-pressed={mode === 'preview'}><Eye /> 미리보기</button>
+            </div>
+          </div>
+
+          <div className={`document-canvas mode-${mode}`}>
+            {mode !== 'preview' && <section className="document-editor-pane" aria-label="Markdown 편집기">
+              <div className="document-pane-label"><PencilLine /> Markdown</div>
+              <textarea ref={textareaRef} value={draft.content_markdown} onChange={(event) => updateDraft({ content_markdown: event.target.value })} spellCheck="true" aria-label="Markdown 본문" placeholder="# 문서 제목&#10;&#10;내용을 작성하세요." />
+            </section>}
+            {mode !== 'edit' && <section className="document-preview-pane" aria-label="Markdown 미리보기">
+              <div className="document-pane-label"><Eye /> 미리보기</div>
+              <article className="markdown-preview">
+                {deferredMarkdown.trim() ? <Markdown
+                  remarkPlugins={[remarkGfm]}
+                  skipHtml
+                  disallowedElements={['img']}
+                  components={{
+                    a: SafeMarkdownLink,
+                  }}
+                >{deferredMarkdown}</Markdown> : <p className="markdown-empty">내용을 입력하면 여기에 안전하게 미리보기가 표시됩니다.</p>}
+              </article>
+            </section>}
+          </div>
+
+          <footer className="document-editor-footer">
+            <span>Markdown · GFM 표, 체크리스트, 코드 지원</span>
+            <span>{draft.editor_name || draft.creator_name ? `최근 편집 ${draft.editor_name || draft.creator_name} · ` : ''}{dateTime(draft.updated_at)} · 버전 {draft.version}</span>
+          </footer>
+        </>}
+      </section>
+    </div>
+  </div>;
+}

--- a/web/src/pages/ActivityDocumentsPage.tsx
+++ b/web/src/pages/ActivityDocumentsPage.tsx
@@ -511,6 +511,17 @@ export function ActivityDocumentsPage() {
     return () => window.removeEventListener('click', guardInternalNavigation, true);
   }, [navigate, saveDraft]);
 
+  const retryLoadDocuments = async () => {
+    if (saveStateRef.current === 'saving') return;
+    if (saveStateRef.current === 'dirty' && !(await saveDraft())) return;
+    if (['conflict', 'error'].includes(saveStateRef.current)) {
+      // eslint-disable-next-line no-alert
+      if (!window.confirm('저장되지 않은 초안을 버리고 문서 목록을 다시 불러올까요?')) return;
+      if (draftRef.current) clearStoredDraft(draftRef.current);
+    }
+    await loadDocuments(selectedId ?? undefined);
+  };
+
   const filteredDocuments = useMemo(() => {
     const query = searchQuery.trim().toLocaleLowerCase('ko-KR');
     if (!query) return documents;
@@ -533,7 +544,7 @@ export function ActivityDocumentsPage() {
       </button>
     </header>
 
-    {pageError && <div className="document-inline-alert error" role="alert"><CloudOff /><span>{pageError}</span><button type="button" onClick={() => { loadDocuments(selectedId ?? undefined); }}>다시 시도</button></div>}
+    {pageError && <div className="document-inline-alert error" role="alert"><CloudOff /><span>{pageError}</span><button type="button" onClick={() => { retryLoadDocuments(); }}>다시 시도</button></div>}
 
     <div className="document-workspace">
       <aside className="document-sidebar" aria-label="활동 문서 목록">
@@ -558,7 +569,7 @@ export function ActivityDocumentsPage() {
             <input className="document-title-input" value={draft.title} maxLength={160} onChange={(event) => updateDraft({ title: event.target.value })} aria-label="문서 제목" placeholder="문서 제목" />
             <div className="document-save-meta">
               <span className={`document-save-state ${saveState}`} role="status" aria-live="polite"><SaveStateIcon state={saveState} />{saveStateCopy[saveState].label}</span>
-              <button onClick={() => { saveDraft(); }} disabled={saveState === 'saving' || saveState === 'saved'} aria-label="지금 저장"><Save /> 저장</button>
+              <button onClick={() => { saveDraft(); }} disabled={saveState === 'saving' || saveState === 'saved' || saveState === 'conflict'} aria-label="지금 저장"><Save /> 저장</button>
             </div>
           </div>
 

--- a/web/src/pages/ActivityDocumentsPage.tsx
+++ b/web/src/pages/ActivityDocumentsPage.tsx
@@ -24,7 +24,7 @@ import {
   Table2,
   Trash2,
 } from 'lucide-react';
-import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useDeferredValue, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import Markdown from 'react-markdown';
 import { Link, useNavigate, useParams } from 'react-router-dom';
 import remarkGfm from 'remark-gfm';
@@ -35,6 +35,7 @@ import '../activity-documents.css';
 
 type EditorMode = 'edit' | 'split' | 'preview';
 type SaveState = 'saved' | 'dirty' | 'saving' | 'conflict' | 'error';
+type TeamGeneration = { teamId: number; generation: number };
 type ApiDocument = Omit<ActivityDocument, 'content_markdown'> & {
   content_markdown?: string;
   markdown_content?: string;
@@ -134,20 +135,76 @@ export function ActivityDocumentsPage() {
   const [creating, setCreating] = useState(false);
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const draftRef = useRef<ActivityDocument | null>(null);
+  const documentsRef = useRef<ActivityDocument[]>([]);
+  const selectedIdRef = useRef<number | null>(null);
   const saveStateRef = useRef<SaveState>('saved');
   const savingRef = useRef(false);
+  const creatingRef = useRef(false);
   const queuedSaveRef = useRef(false);
+  const saveOperationRef = useRef(0);
+  const teamGenerationRef = useRef<TeamGeneration>({ teamId, generation: 0 });
+  const deleteQueueRef = useRef<Promise<void>>(Promise.resolve());
+  const deletingIdsRef = useRef(new Set<number>());
   const documentRequestRef = useRef(0);
   const deferredMarkdown = useDeferredValue(draft?.content_markdown ?? '');
 
   useEffect(() => { draftRef.current = draft; }, [draft]);
   useEffect(() => { saveStateRef.current = saveState; }, [saveState]);
 
-  const openDocument = useCallback((document: ActivityDocument | null, ignoreStoredDraft = false) => {
+  const isCurrentGeneration = useCallback((context: TeamGeneration) => {
+    const current = teamGenerationRef.current;
+    return Object.is(current.teamId, context.teamId) && current.generation === context.generation;
+  }, []);
+
+  const replaceDocuments = useCallback((next: ActivityDocument[]) => {
+    documentsRef.current = next;
+    setDocuments(next);
+  }, []);
+
+  const updateDocuments = useCallback((updater: (current: ActivityDocument[]) => ActivityDocument[]) => {
+    const next = updater(documentsRef.current);
+    documentsRef.current = next;
+    setDocuments(next);
+    return next;
+  }, []);
+
+  useLayoutEffect(() => {
+    const previous = teamGenerationRef.current;
+    if (Object.is(previous.teamId, teamId)) return;
+    if (draftRef.current && ['dirty', 'saving', 'conflict', 'error'].includes(saveStateRef.current)) {
+      storeDraft(draftRef.current);
+    }
+    teamGenerationRef.current = { teamId, generation: previous.generation + 1 };
+    documentRequestRef.current += 1;
+    saveOperationRef.current += 1;
+    savingRef.current = false;
+    creatingRef.current = false;
+    queuedSaveRef.current = false;
+    deleteQueueRef.current = Promise.resolve();
+    deletingIdsRef.current = new Set();
+    documentsRef.current = [];
+    selectedIdRef.current = null;
+    draftRef.current = null;
+    setTeam(null);
+    setDocuments([]);
+    setSelectedId(null);
+    setDraft(null);
+    setSaveState('saved');
+    saveStateRef.current = 'saved';
+    setSaveError('');
+    setPageError('');
+    setDocumentLoading(false);
+    setCreating(false);
+    setLoading(true);
+  }, [teamId]);
+
+  const openDocument = useCallback((document: ActivityDocument | null, ignoreStoredDraft = false, context = teamGenerationRef.current) => {
+    if (!isCurrentGeneration(context) || (document && document.team_id !== context.teamId)) return;
     const stored = document && !ignoreStoredDraft ? readStoredDraft(document) : null;
     if (document && ignoreStoredDraft) clearStoredDraft(document);
     const nextDocument = document && stored ? { ...document, ...stored } : document;
     setSelectedId(document?.document_id ?? null);
+    selectedIdRef.current = document?.document_id ?? null;
     setDraft(nextDocument ? { ...nextDocument } : null);
     draftRef.current = nextDocument ? { ...nextDocument } : null;
     setSaveError(stored ? '브라우저에 남아 있던 저장 전 초안을 복구했습니다.' : '');
@@ -155,10 +212,12 @@ export function ActivityDocumentsPage() {
     const nextState: SaveState = stored ? 'dirty' : 'saved';
     setSaveState(nextState);
     saveStateRef.current = nextState;
-  }, []);
+  }, [isCurrentGeneration]);
 
   const loadDocuments = useCallback(async (preferredId?: number) => {
-    if (!Number.isFinite(teamId) || teamId <= 0) {
+    const context = { ...teamGenerationRef.current };
+    if (!Object.is(context.teamId, teamId) || !isCurrentGeneration(context)) return;
+    if (!Number.isSafeInteger(teamId) || teamId <= 0) {
       setPageError('올바르지 않은 활동 주소입니다.');
       setLoading(false);
       return;
@@ -171,29 +230,29 @@ export function ActivityDocumentsPage() {
         api<TeamSummary[]>('/my-teams'),
         api<ApiDocument[]>(`/teams/${teamId}/documents`),
       ]);
-      if (requestId !== documentRequestRef.current) return;
+      if (!isCurrentGeneration(context) || requestId !== documentRequestRef.current) return;
       let nextDocuments = result.map(normalizeDocument);
       setTeam(teams.find((item) => item.team_id === teamId) ?? null);
-      const nextId = preferredId ?? selectedId;
+      const nextId = preferredId ?? selectedIdRef.current;
       const selectedMeta = nextDocuments.find((item) => item.document_id === nextId) ?? nextDocuments[0] ?? null;
       if (selectedMeta) {
         const detail = normalizeDocument(await api<ApiDocument>(`/teams/${teamId}/documents/${selectedMeta.document_id}`));
-        if (requestId !== documentRequestRef.current) return;
+        if (!isCurrentGeneration(context) || requestId !== documentRequestRef.current) return;
         const selectedDocument = { ...selectedMeta, ...detail };
         nextDocuments = nextDocuments.map((item) => item.document_id === selectedDocument.document_id ? selectedDocument : item);
-        setDocuments(nextDocuments);
-        openDocument(selectedDocument);
+        replaceDocuments(nextDocuments);
+        openDocument(selectedDocument, false, context);
       } else {
-        setDocuments([]);
-        openDocument(null);
+        replaceDocuments([]);
+        openDocument(null, false, context);
       }
     } catch (reason) {
-      if (requestId !== documentRequestRef.current) return;
+      if (!isCurrentGeneration(context) || requestId !== documentRequestRef.current) return;
       setPageError(reason instanceof Error ? reason.message : '문서를 불러오지 못했습니다.');
     } finally {
-      if (requestId === documentRequestRef.current) setLoading(false);
+      if (isCurrentGeneration(context) && requestId === documentRequestRef.current) setLoading(false);
     }
-  }, [openDocument, selectedId, teamId]);
+  }, [isCurrentGeneration, openDocument, replaceDocuments, teamId]);
 
   // 팀이 바뀔 때만 새 목록과 선택 문서를 가져옵니다.
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -201,10 +260,13 @@ export function ActivityDocumentsPage() {
 
   const saveDraft = useCallback(async (snapshot = draftRef.current) => {
     if (!snapshot) return false;
+    const context = { ...teamGenerationRef.current };
+    if (snapshot.team_id !== context.teamId || !isCurrentGeneration(context)) return false;
     if (savingRef.current) {
       queuedSaveRef.current = true;
       return false;
     }
+    const operationId = ++saveOperationRef.current;
     savingRef.current = true;
     setSaveState('saving');
     saveStateRef.current = 'saving';
@@ -219,9 +281,10 @@ export function ActivityDocumentsPage() {
           version: requestSnapshot.version,
         }),
       });
+      if (!isCurrentGeneration(context) || operationId !== saveOperationRef.current) return false;
       const saved = normalizeDocument(result);
       const nextVersion = saved.version ?? requestSnapshot.version + 1;
-      setDocuments((current) => current.map((item) => item.document_id === snapshot.document_id
+      updateDocuments((current) => current.map((item) => item.document_id === snapshot.document_id
         ? { ...item, ...saved, content_markdown: requestSnapshot.content_markdown, version: nextVersion }
         : item));
       const latestDraft = draftRef.current;
@@ -245,6 +308,7 @@ export function ActivityDocumentsPage() {
       }
       return currentSnapshotSaved;
     } catch (reason) {
+      if (!isCurrentGeneration(context) || operationId !== saveOperationRef.current) return false;
       const conflict = reason instanceof ApiError && (reason.status === 409 || reason.code === 'DOCUMENT_VERSION_CONFLICT');
       const nextState: SaveState = conflict ? 'conflict' : 'error';
       setSaveState(nextState);
@@ -254,14 +318,16 @@ export function ActivityDocumentsPage() {
         : reason instanceof Error ? reason.message : '문서를 저장하지 못했습니다.');
       return false;
     } finally {
-      savingRef.current = false;
-      const shouldRunQueuedSave = queuedSaveRef.current && saveStateRef.current === 'dirty';
-      queuedSaveRef.current = false;
-      if (shouldRunQueuedSave) {
-        window.setTimeout(() => { saveDraft(draftRef.current); }, 0);
+      if (isCurrentGeneration(context) && operationId === saveOperationRef.current) {
+        savingRef.current = false;
+        const shouldRunQueuedSave = queuedSaveRef.current && saveStateRef.current === 'dirty';
+        queuedSaveRef.current = false;
+        if (shouldRunQueuedSave) {
+          window.setTimeout(() => { saveDraft(draftRef.current); }, 0);
+        }
       }
     }
-  }, []);
+  }, [isCurrentGeneration, updateDocuments]);
 
   useEffect(() => {
     if (saveState !== 'dirty' || !draftRef.current) return undefined;
@@ -293,6 +359,11 @@ export function ActivityDocumentsPage() {
   }, [draft, saveState]);
 
   const updateDraft = (changes: Partial<Pick<ActivityDocument, 'title' | 'content_markdown'>>) => {
+    if (!draftRef.current || deletingIdsRef.current.has(draftRef.current.document_id)) return;
+    // 로컬 입력은 진행 중인 reload/create보다 최신 사용자 의도입니다.
+    documentRequestRef.current += 1;
+    setLoading(false);
+    setDocumentLoading(false);
     setDraft((current) => {
       if (!current) return current;
       const next = { ...current, ...changes };
@@ -300,7 +371,7 @@ export function ActivityDocumentsPage() {
       return next;
     });
     if ('title' in changes) {
-      setDocuments((current) => current.map((item) => item.document_id === selectedId ? { ...item, ...changes } : item));
+      updateDocuments((current) => current.map((item) => item.document_id === selectedIdRef.current ? { ...item, ...changes } : item));
     }
     setSaveState('dirty');
     saveStateRef.current = 'dirty';
@@ -308,7 +379,9 @@ export function ActivityDocumentsPage() {
   };
 
   const selectDocument = async (document: ActivityDocument) => {
-    if (document.document_id === selectedId) return;
+    if (document.document_id === selectedIdRef.current) return;
+    if (document.team_id !== teamGenerationRef.current.teamId) return;
+    if (deletingIdsRef.current.has(document.document_id)) return;
     if (saveStateRef.current === 'saving') return;
     if (saveStateRef.current === 'dirty') {
       const saved = await saveDraft();
@@ -318,25 +391,29 @@ export function ActivityDocumentsPage() {
       if (!window.confirm('저장되지 않은 변경사항을 버리고 다른 문서로 이동할까요?')) return;
       if (draftRef.current) clearStoredDraft(draftRef.current);
     }
+    const context = { ...teamGenerationRef.current };
+    if (document.team_id !== context.teamId || !isCurrentGeneration(context)) return;
     setDocumentLoading(true);
     setPageError('');
     const requestId = ++documentRequestRef.current;
     try {
       const detail = normalizeDocument(await api<ApiDocument>(`/teams/${teamId}/documents/${document.document_id}`));
-      if (requestId !== documentRequestRef.current) return;
+      if (!isCurrentGeneration(context) || requestId !== documentRequestRef.current
+        || deletingIdsRef.current.has(document.document_id)
+        || !documentsRef.current.some((item) => item.document_id === document.document_id)) return;
       const selectedDocument = { ...document, ...detail };
-      setDocuments((current) => current.map((item) => item.document_id === document.document_id ? selectedDocument : item));
-      openDocument(selectedDocument);
+      updateDocuments((current) => current.map((item) => item.document_id === document.document_id ? selectedDocument : item));
+      openDocument(selectedDocument, false, context);
     } catch (reason) {
-      if (requestId !== documentRequestRef.current) return;
+      if (!isCurrentGeneration(context) || requestId !== documentRequestRef.current) return;
       setPageError(reason instanceof Error ? reason.message : '문서를 불러오지 못했습니다.');
     } finally {
-      if (requestId === documentRequestRef.current) setDocumentLoading(false);
+      if (isCurrentGeneration(context) && requestId === documentRequestRef.current) setDocumentLoading(false);
     }
   };
 
   const createDocument = async () => {
-    if (saveStateRef.current === 'saving') return;
+    if (saveStateRef.current === 'saving' || creatingRef.current || deletingIdsRef.current.size > 0) return;
     if (saveStateRef.current === 'dirty' && !(await saveDraft())) return;
     const preserveDraft = draftRef.current && ['conflict', 'error'].includes(saveStateRef.current);
     const draftToPreserve = preserveDraft ? draftRef.current : null;
@@ -344,31 +421,47 @@ export function ActivityDocumentsPage() {
       // eslint-disable-next-line no-alert
       if (!window.confirm('저장되지 않은 현재 초안을 복구 문서로 보존하고 새 문서를 만들까요?')) return;
     }
+    const context = { ...teamGenerationRef.current };
+    if (!isCurrentGeneration(context)) return;
+    // 선택/삭제 후 실행 중인 상세 조회가 새 문서를 다시 덮어쓰지 못하게 무효화합니다.
+    const requestId = ++documentRequestRef.current;
+    setDocumentLoading(false);
+    setLoading(false);
+    creatingRef.current = true;
     setCreating(true);
     setPageError('');
     try {
-      const result = await api<ApiDocument>(`/teams/${teamId}/documents`, {
+      const result = await api<ApiDocument>(`/teams/${context.teamId}/documents`, {
         method: 'POST',
         body: JSON.stringify({
           title: draftToPreserve ? `${draftToPreserve.title || '제목 없는 문서'} (복구본)`.slice(0, 160) : '제목 없는 문서',
           content_markdown: draftToPreserve ? draftToPreserve.content_markdown : DEFAULT_DOCUMENT,
         }),
       });
+      if (!isCurrentGeneration(context)) return;
       const created = normalizeDocument(result);
       if (draftToPreserve) clearStoredDraft(draftToPreserve);
-      setDocuments((current) => [created, ...current]);
-      openDocument(created);
-      window.requestAnimationFrame(() => textareaRef.current?.focus());
+      updateDocuments((current) => [created, ...current.filter((item) => item.document_id !== created.document_id)]);
+      if (requestId !== documentRequestRef.current) return;
+      openDocument(created, false, context);
+      window.requestAnimationFrame(() => {
+        if (isCurrentGeneration(context) && requestId === documentRequestRef.current) textareaRef.current?.focus();
+      });
     } catch (reason) {
+      if (!isCurrentGeneration(context)) return;
       setPageError(reason instanceof Error ? reason.message : '새 문서를 만들지 못했습니다.');
     } finally {
-      setCreating(false);
+      if (isCurrentGeneration(context)) {
+        creatingRef.current = false;
+        setCreating(false);
+      }
     }
   };
 
   const deleteDocument = async (document: ActivityDocument) => {
+    if (document.team_id !== teamGenerationRef.current.teamId || deletingIdsRef.current.has(document.document_id)) return;
     let target = document;
-    if (document.document_id === selectedId) {
+    if (document.document_id === selectedIdRef.current) {
       if (saveStateRef.current === 'saving') return;
       if (saveStateRef.current === 'dirty') {
         if (!(await saveDraft())) return;
@@ -381,55 +474,97 @@ export function ActivityDocumentsPage() {
     }
     // eslint-disable-next-line no-alert
     if (!window.confirm(`“${target.title || '제목 없는 문서'}” 문서를 삭제할까요? 이 작업은 되돌릴 수 없습니다.`)) return;
-    try {
-      await api(`/teams/${teamId}/documents/${target.document_id}`, {
-        method: 'DELETE',
-        body: JSON.stringify({ version: target.version }),
-      });
-      const remaining = documents.filter((item) => item.document_id !== document.document_id);
-      clearStoredDraft(target);
-      setDocuments(remaining);
-      setPageError('');
-      if (document.document_id === selectedId) {
-        // 목록 응답에는 본문이 없으므로 다음 문서는 상세 조회를 거쳐 열어야 합니다.
-        openDocument(null);
-        if (remaining[0]) await selectDocument(remaining[0]);
-      }
-    } catch (reason) {
-      const conflict = reason instanceof ApiError && (reason.status === 409 || reason.code === 'DOCUMENT_VERSION_CONFLICT');
-      const message = conflict
-        ? '다른 팀원이 문서를 수정해 삭제하지 못했습니다. 최신 목록을 불러오세요.'
-        : reason instanceof Error ? reason.message : '문서를 삭제하지 못했습니다.';
-      if (document.document_id === selectedId) {
-        setSaveError(message);
-        if (conflict) {
-          setSaveState('conflict');
-          saveStateRef.current = 'conflict';
+    const context = { ...teamGenerationRef.current };
+    if (target.team_id !== context.teamId || !isCurrentGeneration(context)) return;
+    const deletingIds = deletingIdsRef.current;
+    deletingIds.add(target.document_id);
+
+    const runDelete = async () => {
+      let replacesSelection = false;
+      let deletionIntentId = 0;
+      try {
+        if (!isCurrentGeneration(context)) return;
+        replacesSelection = selectedIdRef.current === target.document_id;
+        deletionIntentId = ++documentRequestRef.current;
+        setDocumentLoading(false);
+        setLoading(false);
+        await api(`/teams/${context.teamId}/documents/${target.document_id}`, {
+          method: 'DELETE',
+          body: JSON.stringify({ version: target.version }),
+        });
+        if (!isCurrentGeneration(context)) return;
+        const remaining = updateDocuments((current) => current.filter((item) => item.document_id !== target.document_id));
+        clearStoredDraft(target);
+        setPageError('');
+        if (replacesSelection && deletionIntentId === documentRequestRef.current
+          && selectedIdRef.current === target.document_id) {
+          // 목록 메타에는 본문이 없으므로 최신 remaining의 첫 항목을 상세 조회해 엽니다.
+          openDocument(null, false, context);
+          const nextMeta = remaining.find((item) => !deletingIds.has(item.document_id));
+          if (nextMeta) {
+            setDocumentLoading(true);
+            const requestId = ++documentRequestRef.current;
+            try {
+              const detail = normalizeDocument(await api<ApiDocument>(`/teams/${context.teamId}/documents/${nextMeta.document_id}`));
+              if (!isCurrentGeneration(context) || requestId !== documentRequestRef.current
+                || deletingIds.has(nextMeta.document_id)
+                || !documentsRef.current.some((item) => item.document_id === nextMeta.document_id)) return;
+              const nextDocument = { ...nextMeta, ...detail };
+              updateDocuments((current) => current.map((item) => item.document_id === nextDocument.document_id ? nextDocument : item));
+              openDocument(nextDocument, false, context);
+            } catch (reason) {
+              if (!isCurrentGeneration(context) || requestId !== documentRequestRef.current) return;
+              setPageError(reason instanceof Error ? reason.message : '다음 문서를 불러오지 못했습니다.');
+            } finally {
+              if (isCurrentGeneration(context) && requestId === documentRequestRef.current) setDocumentLoading(false);
+            }
+          }
         }
-      } else {
-        // 다른 목록 항목의 삭제 실패가 현재 편집 중인 문서 상태를 오염시키지 않게 합니다.
-        setPageError(message);
+      } catch (reason) {
+        if (!isCurrentGeneration(context)) return;
+        const conflict = reason instanceof ApiError && (reason.status === 409 || reason.code === 'DOCUMENT_VERSION_CONFLICT');
+        const message = conflict
+          ? '다른 팀원이 문서를 수정해 삭제하지 못했습니다. 최신 목록을 불러오세요.'
+          : reason instanceof Error ? reason.message : '문서를 삭제하지 못했습니다.';
+        if (replacesSelection && deletionIntentId === documentRequestRef.current
+          && selectedIdRef.current === target.document_id) {
+          setSaveError(message);
+          if (conflict) {
+            setSaveState('conflict');
+            saveStateRef.current = 'conflict';
+          }
+        } else {
+          setPageError(message);
+        }
+      } finally {
+        deletingIds.delete(target.document_id);
       }
-    }
+    };
+
+    const queuedDelete = deleteQueueRef.current.then(runDelete, runDelete);
+    deleteQueueRef.current = queuedDelete;
+    await queuedDelete;
   };
 
   const reloadConflictedDocument = async () => {
-    if (!selectedId) return;
+    const documentId = selectedIdRef.current;
+    const context = { ...teamGenerationRef.current };
+    if (!documentId || !isCurrentGeneration(context)) return;
     // eslint-disable-next-line no-alert
     if (!window.confirm('서버의 최신본을 불러오면 화면의 로컬 초안이 대체됩니다. 계속할까요?')) return;
     setLoading(true);
     const requestId = ++documentRequestRef.current;
     try {
-      const result = await api<ApiDocument>(`/teams/${teamId}/documents/${selectedId}`);
-      if (requestId !== documentRequestRef.current) return;
+      const result = await api<ApiDocument>(`/teams/${context.teamId}/documents/${documentId}`);
+      if (!isCurrentGeneration(context) || requestId !== documentRequestRef.current) return;
       const latest = normalizeDocument(result);
-      setDocuments((current) => current.map((item) => item.document_id === selectedId ? latest : item));
-      openDocument(latest, true);
+      updateDocuments((current) => current.map((item) => item.document_id === documentId ? latest : item));
+      openDocument(latest, true, context);
     } catch (reason) {
-      if (requestId !== documentRequestRef.current) return;
+      if (!isCurrentGeneration(context) || requestId !== documentRequestRef.current) return;
       setSaveError(reason instanceof Error ? reason.message : '최신 문서를 불러오지 못했습니다.');
     } finally {
-      if (requestId === documentRequestRef.current) setLoading(false);
+      if (isCurrentGeneration(context) && requestId === documentRequestRef.current) setLoading(false);
     }
   };
 
@@ -512,14 +647,18 @@ export function ActivityDocumentsPage() {
   }, [navigate, saveDraft]);
 
   const retryLoadDocuments = async () => {
-    if (saveStateRef.current === 'saving') return;
+    const context = { ...teamGenerationRef.current };
+    if (!isCurrentGeneration(context)) return;
+    if (saveStateRef.current === 'saving' || creatingRef.current || deletingIdsRef.current.size > 0) return;
     if (saveStateRef.current === 'dirty' && !(await saveDraft())) return;
+    if (!isCurrentGeneration(context)) return;
     if (['conflict', 'error'].includes(saveStateRef.current)) {
       // eslint-disable-next-line no-alert
       if (!window.confirm('저장되지 않은 초안을 버리고 문서 목록을 다시 불러올까요?')) return;
       if (draftRef.current) clearStoredDraft(draftRef.current);
     }
-    await loadDocuments(selectedId ?? undefined);
+    if (!isCurrentGeneration(context)) return;
+    await loadDocuments(selectedIdRef.current ?? undefined);
   };
 
   const filteredDocuments = useMemo(() => {
@@ -544,7 +683,7 @@ export function ActivityDocumentsPage() {
       </button>
     </header>
 
-    {pageError && <div className="document-inline-alert error" role="alert"><CloudOff /><span>{pageError}</span><button type="button" onClick={() => { retryLoadDocuments(); }}>다시 시도</button></div>}
+    {pageError && <div className="document-inline-alert error" role="alert"><CloudOff /><span>{pageError}</span><button type="button" onClick={() => { retryLoadDocuments(); }} disabled={creating}>다시 시도</button></div>}
 
     <div className="document-workspace">
       <aside className="document-sidebar" aria-label="활동 문서 목록">

--- a/web/src/pages/ActivityPage.tsx
+++ b/web/src/pages/ActivityPage.tsx
@@ -8,6 +8,7 @@ import {
   Clock3,
   Crown,
   Edit3,
+  FileText,
   Flame,
   ListChecks,
   Plus,
@@ -326,7 +327,7 @@ export function ActivityPage() {
             <div><span className={`source-pill ${selected?.source_type === 'ENTERPRISE_CURRICULUM' ? 'enterprise' : ''}`}>{selected?.source_type === 'ENTERPRISE_CURRICULUM' ? '기업 커리큘럼' : '공모전 활동'} · {selected?.participation_mode === 'PERSONAL' ? '개인' : '팀'}</span><h2>{selected?.team_name}</h2><p>{selected?.part || '역할 설정 전'} · {selected?.due_date ? `${new Date(selected.due_date).toLocaleDateString('ko-KR')}까지` : '종료일 미정'}</p></div>
             <div className="workspace-people"><span>{selected?.participation_mode === 'PERSONAL' ? <Target /> : <UsersRound />}</span><div><strong>{selected?.participation_mode === 'PERSONAL' ? '개인 활동' : '팀 활동'}</strong><small>{selected?.visibility === 'RECRUITING' ? '팀원 모집 중' : '실행 중'}</small></div></div>
           </div>
-          <div className="workspace-manage-row"><span>현재 선택된 활동의 팀원 목표와 역할·프로젝트명을 관리할 수 있습니다.</span><Link to={`/activity/${selectedId}/manage`}><UsersRound /> 팀원 목표·활동 설정</Link></div>
+          <div className="workspace-manage-row"><span>선택한 활동의 목표와 팀 문서를 한곳에서 관리하세요.</span><div><Link to={`/activity/${selectedId}/documents`}><FileText /> 활동 문서</Link><Link to={`/activity/${selectedId}/manage`}><UsersRound /> 팀원 목표·활동 설정</Link></div></div>
           <div className="workspace-progress-grid">
             <div className="dashboard-ring" style={{ '--progress': `${overallProgress * 3.6}deg` } as CSSProperties}><div><strong>{overallProgress}%</strong><span>전체 완료</span></div></div>
             <div className="progress-copy"><h3>{overallProgress >= 70 ? '완주가 가까워지고 있어요' : overallProgress >= 30 ? '좋은 흐름으로 성장 중이에요' : '오늘의 작은 목표부터 시작해요'}</h3><p>{uniqueGoals.filter((goal) => goal.status === '완료').length}개를 완료했고 {uniqueGoals.filter((goal) => goal.status !== '완료').length}개 목표가 남아 있습니다.</p><div className="mini-progress"><span style={{ width: `${startedProgress}%` }} /><em>{startedProgress}% 실행 시작</em></div></div>

--- a/web/src/shared/api/client.ts
+++ b/web/src/shared/api/client.ts
@@ -1,5 +1,21 @@
 export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000';
 
+export class ApiError extends Error {
+  status: number;
+  code?: string;
+  payload: unknown;
+
+  constructor(message: string, status: number, payload?: unknown) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.payload = payload;
+    if (payload && typeof payload === 'object' && 'code' in payload && typeof payload.code === 'string') {
+      this.code = payload.code;
+    }
+  }
+}
+
 export async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
   const token = localStorage.getItem('kkiri_token');
   const headers = new Headers(init.headers);
@@ -11,6 +27,6 @@ export async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
 
   const response = await fetch(`${API_BASE_URL}${path}`, { ...init, headers });
   const data = await response.json().catch(() => ({}));
-  if (!response.ok) throw new Error(data.message || '요청을 처리하지 못했습니다');
+  if (!response.ok) throw new ApiError(data.message || '요청을 처리하지 못했습니다', response.status, data);
   return data as T;
 }

--- a/web/src/shared/api/client.ts
+++ b/web/src/shared/api/client.ts
@@ -16,6 +16,15 @@ export class ApiError extends Error {
   }
 }
 
+const getApiErrorMessage = (payload: unknown) => {
+  if (typeof payload === 'string' && payload.trim()) return payload;
+  if (payload && typeof payload === 'object' && 'message' in payload
+    && typeof payload.message === 'string' && payload.message.trim()) {
+    return payload.message;
+  }
+  return '요청을 처리하지 못했습니다';
+};
+
 export async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
   const token = localStorage.getItem('kkiri_token');
   const headers = new Headers(init.headers);
@@ -26,7 +35,7 @@ export async function api<T>(path: string, init: RequestInit = {}): Promise<T> {
   }
 
   const response = await fetch(`${API_BASE_URL}${path}`, { ...init, headers });
-  const data = await response.json().catch(() => ({}));
-  if (!response.ok) throw new ApiError(data.message || '요청을 처리하지 못했습니다', response.status, data);
+  const data: unknown = await response.json().catch(() => ({}));
+  if (!response.ok) throw new ApiError(getApiErrorMessage(data), response.status, data);
   return data as T;
 }

--- a/web/src/shared/types/domain.ts
+++ b/web/src/shared/types/domain.ts
@@ -145,6 +145,18 @@ export type TeamNotice = {
   updated_at?: string;
 };
 
+export type ActivityDocument = {
+  document_id: number;
+  team_id: number;
+  title: string;
+  content_markdown: string;
+  version: number;
+  creator_name?: string;
+  editor_name?: string;
+  created_at: string;
+  updated_at: string;
+};
+
 export type HeatmapDay = {
   date: string;
   count: number;

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -478,6 +478,7 @@ body { font-size: 16px; line-height: 1.5; }
 }
 .workspace-manage-row a { display: inline-flex; align-items: center; gap: 6px; color: var(--primary); font-weight: 900; white-space: nowrap; }
 .workspace-manage-row svg { width: 17px; }
+.workspace-manage-row > div { display: flex; align-items: center; gap: 14px; }
 .selected-team-panel { margin-top: 14px; padding: 22px; border: 1px solid var(--border); border-radius: 23px; background: #fff; }
 .selected-team-panel .dashboard-section-head > strong { color: var(--primary); font-size: 14px; }
 .selected-team-members { display: grid; grid-template-columns: repeat(auto-fit, minmax(190px, 1fr)); gap: 9px; margin-top: 16px; }
@@ -539,6 +540,7 @@ body { font-size: 16px; line-height: 1.5; }
 }
 @media (max-width: 720px) {
   .workspace-manage-row { align-items: flex-start; flex-direction: column; }
+  .workspace-manage-row > div { width: 100%; align-items: flex-start; flex-direction: column; gap: 8px; }
   .team-goal-filters { grid-template-columns: 1fr 1fr; }
   .team-goal-filters > span { display: none; }
   .team-goal-add { grid-template-columns: 1fr; }


### PR DESCRIPTION
## 변경 내용

- 활동 탭의 선택 활동에서 팀별 문서 작업 공간으로 진입할 수 있게 했습니다.
- 문서 목록·검색·생성·삭제와 제목/본문 편집, 900ms 자동 저장을 구현했습니다.
- Markdown 편집·분할·미리보기 모드와 GFM 표·체크리스트·코드·링크 툴바를 추가했습니다.
- 버전 기반 낙관적 잠금으로 동시 편집 충돌을 409로 감지하고, 로컬 초안 복사·복구본 생성·최신본 불러오기를 제공합니다.
- 새로고침·SPA 이동 전 sessionStorage에 미저장 초안을 보존합니다.
- Markdown 화면을 지연 로딩해 초기 웹 번들을 약 579KB에서 402KB로 줄였습니다.

## 수정 파일

| 파일 | 변경 이유 |
| --- | --- |
| `server/activity-documents/*` | 팀원 권한이 적용된 문서 CRUD와 version 충돌 처리 |
| `server/schema/base.sql` | 활동 문서·soft delete·편집 version 스키마 |
| `server/server.js` | 512KB 제한 JSON 파서와 문서 라우터 연결 |
| `server/scripts/verifyDatabase.js` | 문서 테이블과 팀/작성자/편집자 고아 관계 검증 |
| `server/lib/test/activityDocuments.tests.js` | 입력·권한·트랜잭션·충돌·삭제 회귀 테스트 |
| `web/src/pages/ActivityDocumentsPage.tsx` | Notion형 활동 문서 작업 공간 UI와 자동 저장 |
| `web/src/activity-documents.css` | 데스크톱/모바일 반응형 편집기와 Markdown 스타일 |
| `web/src/pages/ActivityPage.tsx` | 선택 활동의 문서 진입 링크 |
| `web/src/app/AppRoutes.tsx` | 인증된 문서 경로와 route lazy loading |
| `web/src/shared/api/client.ts` | HTTP status/code를 보존하는 typed API 오류 |

## 검증

- [x] 관련 테스트를 실행했습니다.
- [x] 변경된 화면 또는 API를 직접 확인했습니다.
- [x] CodeRabbit 리뷰 5건을 확인하고 모두 반영했습니다.
- 서버 전체 테스트 76/76 통과
- 활동 문서 전용 테스트 12/12 통과
- 웹 lint, TypeScript, production build 통과
- React Native TypeScript와 Jest 4/4 통과
- `npm audit --omit=dev` 취약점 0건
- 실제 MySQL `db:verify` 정상, `orphan_documents: 0`
- 실제 API: 생성 201, stale 수정 409, 비로그인 401, 비팀원 403, 목록 본문 제외 확인
- Chrome 1440px/390px 렌더링에서 표·체크리스트·가로 넘침·안전 링크 확인
- 팀 전환·연속 삭제·생성/재시도 경합에서 이전 비동기 응답이 현재 문서를 덮지 않도록 보강

## 보안 및 데이터 보호

- raw HTML과 Markdown 이미지를 렌더링하지 않고 링크 프로토콜을 allowlist로 제한했습니다.
- 문서 API 응답은 `private, no-store`이며 모든 SQL은 파라미터화했습니다.
- 수정/삭제는 원자적 version 조건과 트랜잭션을 사용하며 삭제는 soft delete입니다.
- 목록 응답에는 Markdown 본문을 포함하지 않습니다.

## 연결 이슈

Closes #103

## 참고 사항

- 계정 탈퇴 시 협업 문서의 작성자 표시를 보존할지 익명화할지는 별도 제품 정책으로 후속 검토합니다.
