### PR TITLE
fix(local): DB 부트스트랩 후 API 자동 복구

### DIFF
--- a/scripts/ensure-api-server.js
+++ b/scripts/ensure-api-server.js
@@ -2,13 +2,15 @@ const fs = require('fs');
 const http = require('http');
 const os = require('os');
 const path = require('path');
-const { spawn } = require('child_process');
+const { execFileSync, spawn } = require('child_process');
 
 const projectRoot = path.resolve(__dirname, '..');
 const serverRoot = path.join(projectRoot, 'server');
 const apiHealthUrl = process.env.KKIRI_API_HEALTH_URL || 'http://127.0.0.1:3000/api/health';
 const dbHealthUrl = process.env.KKIRI_DB_HEALTH_URL || 'http://127.0.0.1:3000/api/db-health';
 const logPath = path.join(os.tmpdir(), 'kkiri-api-server.log');
+const pidPath = path.join(os.tmpdir(), 'kkiri-api-server.pid.json');
+const apiPort = Number(new URL(apiHealthUrl).port || 80);
 
 const wait = (milliseconds) => new Promise((resolve) => setTimeout(resolve, milliseconds));
 
@@ -22,15 +24,76 @@ const requestHealth = (url) => new Promise((resolve) => {
     response.on('end', () => {
       try {
         const payload = JSON.parse(body);
-        resolve({ reachable: true, healthy: response.statusCode === 200 && payload.status === 'ok' });
+        resolve({
+          reachable: true,
+          healthy: response.statusCode === 200 && payload.status === 'ok',
+          payload,
+        });
       } catch {
-        resolve({ reachable: true, healthy: false });
+        resolve({ reachable: true, healthy: false, payload: null });
       }
     });
   });
   request.on('timeout', () => request.destroy());
-  request.on('error', () => resolve({ reachable: false, healthy: false }));
+  request.on('error', () => resolve({ reachable: false, healthy: false, payload: null }));
 });
+
+const isKkiriHealthPayload = (payload) => Boolean(
+  payload
+  && payload.status === 'ok'
+  && Object.prototype.hasOwnProperty.call(payload, 'activity_cache_entries')
+  && Object.prototype.hasOwnProperty.call(payload, 'database'),
+);
+
+const parseWindowsListeningPids = (output, port) => [...new Set(String(output || '')
+  .split(/\r?\n/)
+  .map((line) => line.trim().split(/\s+/))
+  .filter((fields) => fields.length >= 5
+    && fields[0].toUpperCase() === 'TCP'
+    && fields[1].endsWith(`:${port}`)
+    && fields[3].toUpperCase() === 'LISTENING')
+  .map((fields) => Number(fields[4]))
+  .filter((pid) => Number.isSafeInteger(pid) && pid > 0 && pid !== process.pid))];
+
+const readTrackedPid = () => {
+  try {
+    const record = JSON.parse(fs.readFileSync(pidPath, 'utf8'));
+    return record?.projectRoot === projectRoot && Number.isSafeInteger(record.pid) ? record.pid : null;
+  } catch {
+    return null;
+  }
+};
+
+const findApiPids = () => {
+  const pids = [readTrackedPid()].filter(Boolean);
+  if (process.platform === 'win32') {
+    try {
+      const output = execFileSync('netstat.exe', ['-ano', '-p', 'tcp'], { encoding: 'utf8' });
+      pids.push(...parseWindowsListeningPids(output, apiPort));
+    } catch {
+      // PID 파일이 있으면 해당 프로세스만으로 복구를 계속합니다.
+    }
+  }
+  return [...new Set(pids)];
+};
+
+const recycleStaleApi = async () => {
+  const pids = findApiPids();
+  if (!pids.length) return false;
+  for (const pid of pids) {
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch (error) {
+      if (error.code !== 'ESRCH') throw error;
+    }
+  }
+  try { fs.rmSync(pidPath, { force: true }); } catch { /* 다음 시작에서 덮어씁니다. */ }
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    if (!(await requestHealth(apiHealthUrl)).reachable) return true;
+    await wait(250);
+  }
+  return !(await requestHealth(apiHealthUrl)).reachable;
+};
 
 const waitForDatabase = async () => {
   for (let attempt = 0; attempt < 40; attempt += 1) {
@@ -51,6 +114,7 @@ const startServer = () => {
   });
   child.unref();
   fs.closeSync(output);
+  fs.writeFileSync(pidPath, JSON.stringify({ pid: child.pid, projectRoot, startedAt: new Date().toISOString() }));
   return child.pid;
 };
 
@@ -63,7 +127,13 @@ const run = async () => {
 
   const api = await requestHealth(apiHealthUrl);
   if (api.reachable) {
-    throw new Error('API 서버는 실행 중이지만 데이터베이스 연결이 끊겼습니다. 서버 로그를 확인해주세요.');
+    if (!isKkiriHealthPayload(api.payload)) {
+      throw new Error(`포트 ${apiPort}을 다른 프로그램이 사용 중입니다. 해당 프로그램을 종료해주세요.`);
+    }
+    console.log('데이터베이스 연결이 끊긴 이전 끼리끼리 API를 재시작합니다.');
+    if (!(await recycleStaleApi())) {
+      throw new Error(`포트 ${apiPort}의 이전 API를 종료하지 못했습니다. 서버 로그를 확인해주세요.`);
+    }
   }
 
   const pid = startServer();
@@ -73,7 +143,11 @@ const run = async () => {
   console.log(`API 서버를 시작했습니다. PID ${pid}`);
 };
 
-run().catch((error) => {
-  console.error(error.message);
-  process.exitCode = 1;
-});
+if (require.main === module) {
+  run().catch((error) => {
+    console.error(error.message);
+    process.exitCode = 1;
+  });
+}
+
+module.exports = { isKkiriHealthPayload, parseWindowsListeningPids };

--- a/server/lib/test/ensureApiServer.tests.js
+++ b/server/lib/test/ensureApiServer.tests.js
@@ -1,0 +1,27 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  isKkiriHealthPayload,
+  parseWindowsListeningPids,
+} = require('../../../scripts/ensure-api-server');
+
+test('Windows netstat 결과에서 지정 포트의 LISTENING PID만 찾는다', () => {
+  const output = [
+    'TCP    0.0.0.0:3000     0.0.0.0:0      LISTENING       42720',
+    'TCP    [::]:3000        [::]:0         LISTENING       42720',
+    'TCP    127.0.0.1:5173   0.0.0.0:0      LISTENING       50000',
+    'TCP    127.0.0.1:3000   127.0.0.1:9    ESTABLISHED     42720',
+  ].join('\r\n');
+  assert.deepEqual(parseWindowsListeningPids(output, 3000), [42720]);
+});
+
+test('끼리끼리 health 응답만 오래된 API 재시작 대상으로 인정한다', () => {
+  assert.equal(isKkiriHealthPayload({
+    status: 'ok',
+    database: 'connected',
+    activity_cache_entries: 1,
+  }), true);
+  assert.equal(isKkiriHealthPayload({ status: 'ok' }), false);
+  assert.equal(isKkiriHealthPayload(null), false);
+});

--- a/server/server.js
+++ b/server/server.js
@@ -893,11 +893,13 @@ app.get('/api/db-health', async (req, res) => {
       && Number(teamStats.orphan_memberships || 0) === 0
       && crawler?.status === 'completed'
       && Number(crawler?.error_count || 0) === 0;
-    const healthy = schemaOk && dataOk;
+    const available = schemaOk;
     db.state = 'connected';
-    res.status(healthy ? 200 : 503).json({
-      status: healthy ? 'ok' : 'degraded',
-      message: healthy ? '데이터베이스 연결·스키마·수집 데이터 품질을 확인했습니다' : '데이터베이스 검증 항목을 확인해주세요',
+    res.status(available ? 200 : 503).json({
+      status: available ? 'ok' : 'degraded',
+      message: dataOk
+        ? '데이터베이스 연결·스키마·수집 데이터 품질을 확인했습니다'
+        : '데이터베이스 연결과 스키마는 정상이며 일부 수집 데이터 품질을 확인해주세요',
       database: connection.database_name,
       port: Number(connection.port),
       account: connection.account,


### PR DESCRIPTION
## 변경 내용

- DB 부트스트랩 뒤 기존 끼리끼리 API의 연결이 끊기면 3000번 포트의 해당 API만 식별해 자동 재시작합니다.
- 새로 시작한 API의 PID와 작업 경로를 임시 PID 파일에 기록해 이후 복구 대상을 제한합니다.
- 3000번 포트를 다른 서비스가 사용하면 강제 종료하지 않고 명확한 오류를 반환합니다.
- DB 연결·필수 스키마 가용성과 포스터 누락 같은 수집 데이터 품질을 분리했습니다. 이미지 품질 경고만으로 앱 시작을 503 처리하지 않습니다.

## 수정 파일

- `scripts/ensure-api-server.js`: 오래된 API 식별·종료·재시작 및 PID 추적
- `server/server.js`: DB 가용성과 수집 데이터 품질 상태 분리
- `server/lib/test/ensureApiServer.tests.js`: 포트 PID 파싱과 서비스 식별 테스트

## 검증

- 서버 테스트 85/85 통과
- `ensure-api-server.js` 구문 검사 통과
- 오래된 API PID 42720 자동 종료 후 새 API PID 32028 시작 확인
- `/api/db-health` HTTP 200 및 `kkiri_local` 연결 확인
- `/api/activities` 노출 420건 확인
- 바탕화면 `끼리끼리_실행.bat` 실제 실행 및 `http://localhost:5173/login` HTTP 200 확인

## 연결 이슈

Closes #113
